### PR TITLE
lognnoteをつなぐ橋を仮描画

### DIFF
--- a/Application/Resources/Data/Effect/Emitters/TapEffect_Triangle.json
+++ b/Application/Resources/Data/Effect/Emitters/TapEffect_Triangle.json
@@ -53,21 +53,21 @@
         "direction_Max": {
             "x": 1.0,
             "y": 1.0,
-            "z": 1.0
+            "z": 0.0
         },
         "direction_Min": {
             "x": -1.0,
             "y": -1.0,
-            "z": -1.0
+            "z": 0.0
         },
-        "direction_Random": false,
-        "direction_Type": 0,
+        "direction_Random": true,
+        "direction_Type": 2,
         "direction_Value": {
             "x": 0.0,
             "y": 0.0,
             "z": 0.0
         },
-        "emitCount": 15,
+        "emitCount": 30,
         "emitPerSecond": 10,
         "isLoop": false,
         "lifeTime": 0.0,
@@ -75,7 +75,7 @@
         "lifeTime_Min": 0.5,
         "lifeTime_Random": false,
         "lifeTime_Type": 2,
-        "lifeTime_Value": 0.6,
+      "lifeTime_Value": 0.6,
         "modifiers": [
             "AlphaOverLifetime",
             "DecelerationModifier"
@@ -99,12 +99,12 @@
         "rotationSpeed_Max": {
             "x": 3.141590118408203,
             "y": 3.1419999599456787,
-            "z": 0.0
+            "z": 3.1419999599456787
         },
         "rotationSpeed_Min": {
             "x": -3.141590118408203,
             "y": -3.1419999599456787,
-            "z": 0.0
+            "z": -3.1419999599456787
         },
         "rotationSpeed_Random": true,
         "rotationSpeed_Value": {

--- a/Application/RhythmProject.vcxproj
+++ b/Application/RhythmProject.vcxproj
@@ -136,6 +136,7 @@
       <AdditionalIncludeDirectories>$(SolutionDir)Source\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/Application/Source/Application/Effects/TapEffects/TriggerEffects.cpp
+++ b/Application/Source/Application/Effects/TapEffects/TriggerEffects.cpp
@@ -13,6 +13,7 @@ uint32_t TriggerEffects::countPerEmit_ = 16; // 一度に発生するパーテ�
 float TriggerEffects::baseSize = 0.3f;
 float TriggerEffects::centerSize = 1.0f;
 uint32_t TriggerEffects::textureHandle_ = 0;
+uint32_t TriggerEffects::gradationTexture_ = 0; // グラデーション用のテクスチャ
 Vector4 TriggerEffects::commonColor_ = Vector4(0.3f, 0.6f, 1.0f, 0.7f); // 共通の色
 
 ParticleEmitter TriggerEffects::emitter_; // ほそ長いのを出すエミッター
@@ -21,40 +22,6 @@ ParticleEmitter TriggerEffects::triangleEmitter_; // 三角形を出すエミッ
 void TriggerEffects::Initialize()
 {
     textureHandle_ = TextureManager::GetInstance()->Load("circle.png");
-
-    // 2x2 y+向き
-    Plane plane;
-    plane.SetSize(Vector2(1.0f, 1.0f) * 2);
-    plane.SetNormal(Vector3(0, 1, 0));
-    plane.SetPivot(Vector3(0, 0, 0));
-
-    plane.Generate("pY1x1Plane");
-
-    //// 2x2 z-向き
-    //Plane nZplane;
-    //nZplane.SetSize(Vector2(1.0f, 1.0f) * 2);
-    //nZplane.SetNormal(Vector3(0, 0, -1));
-    //nZplane.SetPivot(Vector3(0, 0, 0));
-
-    //nZplane.Generate("nZ1x1Plane");
-
-    // ほそ長いやつ
-    Plane plane2;
-    plane2.SetSize(Vector2(0.1f, 0.7f) * 5.0f);
-    plane2.SetNormal(Vector3(0, 0, -1));
-    plane2.SetPivot(Vector3(0, 0, 0));
-
-    plane2.Generate("nZ0.1x0.7Plane");
-
-
-    Triangle triangle;
-    triangle.SetNormal(Vector3(0, 0, -1));
-    triangle.SetVertices({
-        Vector3(0, 0.5f, 0),
-        Vector3(0.5f, -0.5f, 0),
-        Vector3(-0.5f, -0.5f, 0)
-        });
-    triangle.Generate("nZ1_1Triangle");
 
     // ほそ長いのを出すエミッター
     emitter_.Initialize("TapEffect_01");

--- a/Application/Source/Application/Effects/TapEffects/TriggerEffects.h
+++ b/Application/Source/Application/Effects/TapEffects/TriggerEffects.h
@@ -31,6 +31,8 @@ private:
     static Vector4 commonColor_;
 
     static uint32_t textureHandle_;
+    static uint32_t gradationTexture_;
+
 
     static ParticleEmitter emitter_; // ほぞ長いのを出すエミッター
     static ParticleEmitter triangleEmitter_; // 三角形を出すエミッター

--- a/Application/Source/Application/Note/Note.h
+++ b/Application/Source/Application/Note/Note.h
@@ -70,11 +70,14 @@ public:
     void Update(float _deltaTime) override;
     void Draw(const Camera* _camera) override;
 
-    void SetNextNote(std::shared_ptr<Note> _nextNote) {
-        nextNote_ = _nextNote; 
+    void SetBeforeNote(std::shared_ptr<Note> _beforeNote) {
+        beforeNote_= _beforeNote;
     }
 private:
 
-    std::shared_ptr<Note> nextNote_ = nullptr;  // 次のノーツ
+    std::shared_ptr<Note> beforeNote_ = nullptr;  // 前のノーツ
+    std::unique_ptr<ObjectModel> noteBridge_ = nullptr; // ノーツブリッジ
+
+    float length_ = 0.0f; // ノーツの長さ
 
 };

--- a/Application/Source/Application/Note/NotesSystem.h
+++ b/Application/Source/Application/Note/NotesSystem.h
@@ -32,11 +32,14 @@ public:
 
     void SetStopwatch(Stopwatch* _stopwatch) { stopwatch_ = _stopwatch; }
 
+    void Reload();
+
 private:
 
     void CreateNormalNote(uint32_t _laneIndex, float _speed, float _targetTime);
 
-    void CreateLongNote(uint32_t _laneIndex, float _speed, float _targetTime,std::shared_ptr<Note> _nextNote);
+    void CreateLongNote(uint32_t _laneIndex, float _speed, float _targetTime,std::shared_ptr<Note> _beforeNote);
+    void CreateLongNote(const NoteData& _noteData);
     std::shared_ptr<Note> CreateNextNoteForLongNote(uint32_t _laneIndex, float _speed, float _targetTime);
 
     void DebugWindow();
@@ -46,7 +49,8 @@ private:
     float noteSize_ = 0.0f;
 
     float judgeLinePosition_ = 0.0f;
-    float missJudgeThreshold_ = 0.5f;
+    // miss判定で消えるまでの猶予座標
+    float missJudgeThreshold_ = 3.0f;
 
     Lane* lane_ = nullptr;
     std::list<std::shared_ptr<Note>> notes_;

--- a/Application/Source/Application/Scene/GameScene.h
+++ b/Application/Source/Application/Scene/GameScene.h
@@ -30,6 +30,15 @@ public:
 
 private:
 
+    void GenerateModels();
+
+    /// <summary>
+    /// 譜面データの読み込みを待機する
+    /// </summary>
+    /// <param name="_filePath">譜面データのファイルパス</param>
+    /// <returns> 読み込み完了 or 読み込み済みなら true </returns>
+    bool IsComplateLoadBeatMap();
+
     // シーン関連
     Camera SceneCamera_ = {};
     DebugCamera debugCamera_ = {};

--- a/Application/imgui.ini
+++ b/Application/imgui.ini
@@ -15,14 +15,14 @@ Collapsed=0
 DockId=0x00000006,2
 
 [Window][Debug]
-Pos=939,31
-Size=126,321
+Pos=946,24
+Size=140,321
 Collapsed=0
 DockId=0x00000002,0
 
 [Window][DebugWindow]
-Pos=1067,31
-Size=199,321
+Pos=1088,24
+Size=185,321
 Collapsed=0
 DockId=0x00000003,0
 
@@ -50,25 +50,30 @@ Collapsed=0
 DockId=0x00000006,3
 
 [Window][TimeLine]
-Pos=0,588
-Size=1280,132
+Pos=0,17
+Size=32,19
 Collapsed=0
 DockId=0x00000005,0
 
 [Window][JudgeResult]
 Pos=26,21
-Size=107,123
+Size=119,128
 Collapsed=0
 
 [Window][Emitter]
-Pos=3,6
-Size=245,717
+Pos=-1,-1
+Size=297,717
+Collapsed=0
+
+[Window][TextureManager]
+Pos=60,60
+Size=226,99
 Collapsed=0
 
 [Docking][Data]
-DockNode    ID=0x00000001 Pos=939,31 Size=327,321 Split=X Selected=0x1E7E18E3
-  DockNode  ID=0x00000002 Parent=0x00000001 SizeRef=173,168 Selected=0x1E7E18E3
-  DockNode  ID=0x00000003 Parent=0x00000001 SizeRef=275,168 Selected=0x4B6712B0
+DockNode    ID=0x00000001 Pos=946,24 Size=327,321 Split=X Selected=0x1E7E18E3
+  DockNode  ID=0x00000002 Parent=0x00000001 SizeRef=140,168 Selected=0x1E7E18E3
+  DockNode  ID=0x00000003 Parent=0x00000001 SizeRef=185,168 Selected=0x4B6712B0
 DockNode    ID=0x00000006 Pos=1077,377 Size=184,244 Selected=0x1FDCDEE6
 DockSpace   ID=0x08BD597D Window=0x1BBC0F80 Pos=0,0 Size=32,32 Split=Y
   DockNode  ID=0x00000004 Parent=0x08BD597D SizeRef=1280,586 CentralNode=1


### PR DESCRIPTION
- NoteクラスでbeforeNoteを使用するように変更し、noteBridgeの初期化を追加。
- NotesSystemにReloadメソッドを追加し、ノーツのリセット機能を実装。
- GameSceneにモデル生成とビートマップ読み込み確認機能を追加。
- imgui.iniでデバッグウィンドウの位置とサイズを調整。