### PR TITLE
リリース用ビルド用調整

### DIFF
--- a/Application/Source/Application/Note/Judge/NoteJudge.h
+++ b/Application/Source/Application/Note/Judge/NoteJudge.h
@@ -24,6 +24,7 @@ public:
 
     void OnEvent(const GameEvent& _event) override;
 
+    void SetIsDrawLine(bool _isDraw) { isDrawLine = _isDraw; }
 
     void SetPosition(float _position) { position_ = _position; }
     void SetLaneTotalWidth(float _width) { laneTotalWidth_ = _width; }

--- a/Application/Source/Application/Note/NotesSystem.h
+++ b/Application/Source/Application/Note/NotesSystem.h
@@ -34,6 +34,8 @@ public:
 
     void Reload();
 
+    void playing(bool _playing) { playing_ = _playing; }
+
 private:
 
     void CreateNormalNote(uint32_t _laneIndex, float _speed, float _targetTime);

--- a/Application/Source/Application/Scene/GameScene.cpp
+++ b/Application/Source/Application/Scene/GameScene.cpp
@@ -48,11 +48,12 @@ void GameScene::Initialize(SceneData* _sceneData)
     lane_->Initialize();
 
     notesSystem_ = std::make_unique<NotesSystem>(lane_.get());
-    notesSystem_->Initialize(10.0f, 1.0f);
+    notesSystem_->Initialize(30.0f, 1.0f);
     notesSystem_->SetStopwatch(stopwatch_.get());
 
     judgeLine_ = std::make_unique<JudgeLine>();
     judgeLine_->Initialize();
+
 
 
     noteJudge_ = std::make_unique<NoteJudge>();
@@ -78,6 +79,13 @@ void GameScene::Initialize(SceneData* _sceneData)
     beatManager_->SetStopWatch(stopwatch_.get());
     beatManager_->SetEnableSound(false);
 
+
+
+#ifdef _DEBUG
+    noteJudge_->SetIsDrawLine(true);
+#else
+    noteJudge_->SetIsDrawLine(false);
+#endif // _DEBUG
     isBeatMapLoaded_ = false;
     frameCount_ = 0;
 
@@ -91,6 +99,10 @@ void GameScene::Update()
         return;
 
     stopwatch_->Update();
+    if (input_->IsKeyTriggered(DIK_R))
+    {
+        notesSystem_->Reload();
+    }
 
 #ifdef _DEBUG
     if (input_->IsKeyTriggered(DIK_F1))
@@ -98,6 +110,7 @@ void GameScene::Update()
         enableDebugCamera_ = !enableDebugCamera_;
     }
     stopwatch_->ShowDebugWindow();
+
 
     judgeResult_->DebugWindow();
 
@@ -245,6 +258,8 @@ bool GameScene::IsComplateLoadBeatMap()
         // 開始する
         beatManager_->Start();
         stopwatch_->Start();
+
+        notesSystem_->playing(true);
 
         isBeatMapLoaded_ = true;
     }


### PR DESCRIPTION
描画ライン設定機能と再生状態管理の追加

`NoteJudge.h`に`SetIsDrawLine`メソッドを追加し、描画ラインの表示状態を設定可能にしました。 `NotesSystem.h`に`playing`メソッドを追加し、再生状態を管理できるようにしました。 `GameScene.cpp`の`Initialize`メソッドで、`notesSystem_`の初期化パラメータを変更し、`noteJudge_`の初期化処理を追加しました。 デバッグビルド時に`noteJudge_`の描画ライン設定を条件付きで変更する処理を追加しました。
`Update`メソッドに`DIK_R`キーでのリロード処理を追加し、`IsComplateLoadBeatMap`メソッドでビートマップ読み込み完了時に再生状態を設定する処理を追加しました。