### PR TITLE
新しいシーンクラスを追加

### DIFF
--- a/Application/RhythmProject.vcxproj
+++ b/Application/RhythmProject.vcxproj
@@ -162,6 +162,9 @@
     <ClCompile Include="Source\Application\Note\Note.cpp" />
     <ClCompile Include="Source\Application\Note\NotesSystem.cpp" />
     <ClCompile Include="Source\Application\Scene\GameScene.cpp" />
+    <ClCompile Include="Source\Application\Scene\ResultScene.cpp" />
+    <ClCompile Include="Source\Application\Scene\SelectScene.cpp" />
+    <ClCompile Include="Source\Application\Scene\TitleScene.cpp" />
     <ClCompile Include="Source\Essential\ParticleModifierFactory.cpp" />
     <ClCompile Include="Source\Essential\SampleFramework.cpp" />
     <ClCompile Include="Source\Essential\SampleScene.cpp" />
@@ -193,6 +196,9 @@
     <ClInclude Include="Source\Application\Note\Note.h" />
     <ClInclude Include="Source\Application\Note\NotesSystem.h" />
     <ClInclude Include="Source\Application\Scene\GameScene.h" />
+    <ClInclude Include="Source\Application\Scene\ResultScene.h" />
+    <ClInclude Include="Source\Application\Scene\SelectScene.h" />
+    <ClInclude Include="Source\Application\Scene\TitleScene.h" />
     <ClInclude Include="Source\Essential\ParticleModifierFactory.h" />
     <ClInclude Include="Source\Essential\SampleFramework.h" />
     <ClInclude Include="Source\Essential\SampleScene.h" />

--- a/Application/RhythmProject.vcxproj.filters
+++ b/Application/RhythmProject.vcxproj.filters
@@ -109,6 +109,15 @@
     <ClCompile Include="Source\Application\Effects\TapEffects\LightPillarModifier.cpp">
       <Filter>Application\Effects\TapEffects</Filter>
     </ClCompile>
+    <ClCompile Include="Source\Application\Scene\TitleScene.cpp">
+      <Filter>Application\Scene</Filter>
+    </ClCompile>
+    <ClCompile Include="Source\Application\Scene\SelectScene.cpp">
+      <Filter>Application\Scene</Filter>
+    </ClCompile>
+    <ClCompile Include="Source\Application\Scene\ResultScene.cpp">
+      <Filter>Application\Scene</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Source\Essential\SampleFramework.h">
@@ -182,6 +191,15 @@
     </ClInclude>
     <ClInclude Include="Source\Application\Effects\TapEffects\LightPillarModifier.h">
       <Filter>Application\Effects\TapEffects</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\Application\Scene\TitleScene.h">
+      <Filter>Application\Scene</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\Application\Scene\SelectScene.h">
+      <Filter>Application\Scene</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\Application\Scene\ResultScene.h">
+      <Filter>Application\Scene</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Application/Source/Application/Scene/ResultScene.cpp
+++ b/Application/Source/Application/Scene/ResultScene.cpp
@@ -1,0 +1,64 @@
+#include "ResultScene.h"
+
+void ResultScene::Initialize(SceneData* _sceneData)
+{
+    SceneCamera_.Initialize();
+    SceneCamera_.translate_ = { 0,5,-13 };
+    SceneCamera_.rotate_ = { 0.26f,0,0 };
+    SceneCamera_.UpdateMatrix();
+    debugCamera_.Initialize();
+
+
+    lineDrawer_ = LineDrawer::GetInstance();
+    lineDrawer_->Initialize();
+    lineDrawer_->SetCameraPtr(&SceneCamera_);
+
+    input_ = Input::GetInstance();
+
+    particleSystem_ = ParticleSystem::GetInstance();
+    particleSystem_->SetCamera(&SceneCamera_);
+
+    lightGroup_ = std::make_shared<LightGroup>();
+    lightGroup_->Initialize();
+
+
+    LightingSystem::GetInstance()->SetActiveGroup(lightGroup_);
+}
+
+void ResultScene::Update()
+{
+#ifdef _DEBUG
+
+    // デバッグカメラ
+    if (Input::GetInstance()->IsKeyTriggered(DIK_F1))
+        enableDebugCamera_ = !enableDebugCamera_;
+
+    lightGroup_->ImGui();
+
+#endif // _DEBUG
+
+    if (enableDebugCamera_)
+    {
+        debugCamera_.Update();
+        SceneCamera_.matView_ = debugCamera_.matView_;
+
+        SceneCamera_.TransferData();
+    }
+    else
+    {
+        SceneCamera_.Update();
+        SceneCamera_.UpdateMatrix();
+    }
+
+    particleSystem_->Update();
+
+
+
+}
+
+void ResultScene::Draw()
+{
+
+}
+
+void ResultScene::DrawShadow() {}

--- a/Application/Source/Application/Scene/ResultScene.h
+++ b/Application/Source/Application/Scene/ResultScene.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <Features/Scene/Interface/BaseScene.h>
+#include <Features/Camera/Camera/Camera.h>
+#include <Features/Camera/DebugCamera/DebugCamera.h>
+#include <System/Input/Input.h>
+#include <Features/LineDrawer/LineDrawer.h>
+#include <System/Time/Stopwatch.h>
+#include <Features/Effect/Manager/ParticleSystem.h>
+
+
+class ResultScene : public BaseScene
+{
+public:
+    ResultScene() = default;
+    ~ResultScene() override = default;
+
+    void Initialize(SceneData* _sceneData) override;
+
+    void Update() override;
+
+    void Draw() override;
+    void DrawShadow() override;
+
+
+private:
+    // シーン関連
+    Camera SceneCamera_ = {};
+    DebugCamera debugCamera_ = {};
+    bool enableDebugCamera_ = false;
+
+    LineDrawer* lineDrawer_ = nullptr;
+    Input* input_ = nullptr;
+    ParticleSystem* particleSystem_ = nullptr;
+
+    std::shared_ptr<LightGroup> lightGroup_ = nullptr;
+
+};

--- a/Application/Source/Application/Scene/SelectScene.cpp
+++ b/Application/Source/Application/Scene/SelectScene.cpp
@@ -1,0 +1,63 @@
+#include "SelectScene.h"
+
+void SelectScene::Initialize(SceneData* _sceneData)
+{
+    SceneCamera_.Initialize();
+    SceneCamera_.translate_ = { 0,5,-13 };
+    SceneCamera_.rotate_ = { 0.26f,0,0 };
+    SceneCamera_.UpdateMatrix();
+    debugCamera_.Initialize();
+
+
+    lineDrawer_ = LineDrawer::GetInstance();
+    lineDrawer_->Initialize();
+    lineDrawer_->SetCameraPtr(&SceneCamera_);
+
+    input_ = Input::GetInstance();
+
+    particleSystem_ = ParticleSystem::GetInstance();
+    particleSystem_->SetCamera(&SceneCamera_);
+
+    lightGroup_ = std::make_shared<LightGroup>();
+    lightGroup_->Initialize();
+
+
+    LightingSystem::GetInstance()->SetActiveGroup(lightGroup_);
+}
+
+void SelectScene::Update()
+{
+#ifdef _DEBUG
+
+    // デバッグカメラ
+    if (Input::GetInstance()->IsKeyTriggered(DIK_F1))
+        enableDebugCamera_ = !enableDebugCamera_;
+
+    lightGroup_->ImGui();
+
+#endif // _DEBUG
+
+    if (enableDebugCamera_)
+    {
+        debugCamera_.Update();
+        SceneCamera_.matView_ = debugCamera_.matView_;
+        SceneCamera_.TransferData();
+    }
+    else
+    {
+        SceneCamera_.Update();
+        SceneCamera_.UpdateMatrix();
+    }
+
+    particleSystem_->Update();
+
+
+
+}
+
+void SelectScene::Draw()
+{
+
+}
+
+void SelectScene::DrawShadow() {}

--- a/Application/Source/Application/Scene/SelectScene.h
+++ b/Application/Source/Application/Scene/SelectScene.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <Features/Scene/Interface/BaseScene.h>
+#include <Features/Camera/Camera/Camera.h>
+#include <Features/Camera/DebugCamera/DebugCamera.h>
+#include <System/Input/Input.h>
+#include <Features/LineDrawer/LineDrawer.h>
+#include <System/Time/Stopwatch.h>
+#include <Features/Effect/Manager/ParticleSystem.h>
+
+
+class SelectScene : public BaseScene
+{
+public:
+    SelectScene() = default;
+    ~SelectScene() override = default;
+
+    void Initialize(SceneData* _sceneData) override;
+
+    void Update() override;
+
+    void Draw() override;
+    void DrawShadow() override;
+
+
+private:
+    // シーン関連
+    Camera SceneCamera_ = {};
+    DebugCamera debugCamera_ = {};
+    bool enableDebugCamera_ = false;
+
+    LineDrawer* lineDrawer_ = nullptr;
+    Input* input_ = nullptr;
+    ParticleSystem* particleSystem_ = nullptr;
+
+    std::shared_ptr<LightGroup> lightGroup_ = nullptr;
+
+};

--- a/Application/Source/Application/Scene/TitleScene.cpp
+++ b/Application/Source/Application/Scene/TitleScene.cpp
@@ -1,0 +1,63 @@
+#include "TitleScene.h"
+
+void TitleScene::Initialize(SceneData* _sceneData)
+{
+    SceneCamera_.Initialize();
+    SceneCamera_.translate_ = { 0,5,-13 };
+    SceneCamera_.rotate_ = { 0.26f,0,0 };
+    SceneCamera_.UpdateMatrix();
+    debugCamera_.Initialize();
+
+
+    lineDrawer_ = LineDrawer::GetInstance();
+    lineDrawer_->Initialize();
+    lineDrawer_->SetCameraPtr(&SceneCamera_);
+
+    input_ = Input::GetInstance();
+
+    particleSystem_ = ParticleSystem::GetInstance();
+    particleSystem_->SetCamera(&SceneCamera_);
+
+    lightGroup_ = std::make_shared<LightGroup>();
+    lightGroup_->Initialize();
+
+
+    LightingSystem::GetInstance()->SetActiveGroup(lightGroup_);
+}
+
+void TitleScene::Update()
+{
+#ifdef _DEBUG
+
+    // デバッグカメラ
+    if (Input::GetInstance()->IsKeyTriggered(DIK_F1))
+        enableDebugCamera_ = !enableDebugCamera_;
+
+    lightGroup_->ImGui();
+
+#endif // _DEBUG
+
+    if (enableDebugCamera_)
+    {
+        debugCamera_.Update();
+        SceneCamera_.matView_ = debugCamera_.matView_;
+        SceneCamera_.TransferData();
+    }
+    else
+    {
+        SceneCamera_.Update();
+        SceneCamera_.UpdateMatrix();
+    }
+
+    particleSystem_->Update();
+
+
+
+}
+
+void TitleScene::Draw()
+{
+
+}
+
+void TitleScene::DrawShadow(){}

--- a/Application/Source/Application/Scene/TitleScene.h
+++ b/Application/Source/Application/Scene/TitleScene.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <Features/Scene/Interface/BaseScene.h>
+#include <Features/Camera/Camera/Camera.h>
+#include <Features/Camera/DebugCamera/DebugCamera.h>
+#include <System/Input/Input.h>
+#include <Features/LineDrawer/LineDrawer.h>
+#include <System/Time/Stopwatch.h>
+#include <Features/Effect/Manager/ParticleSystem.h>
+
+
+class TitleScene : public BaseScene
+{
+public:
+    TitleScene() = default;
+    ~TitleScene() override = default;
+
+    void Initialize(SceneData* _sceneData) override;
+
+    void Update() override;
+
+    void Draw() override;
+    void DrawShadow() override;
+
+
+private:
+    // シーン関連
+    Camera SceneCamera_ = {};
+    DebugCamera debugCamera_ = {};
+    bool enableDebugCamera_ = false;
+
+    LineDrawer* lineDrawer_ = nullptr;
+    Input* input_ = nullptr;
+    ParticleSystem* particleSystem_ = nullptr;
+
+    std::shared_ptr<LightGroup> lightGroup_ = nullptr;
+
+};

--- a/Application/Source/Essential/SceneFactory.cpp
+++ b/Application/Source/Essential/SceneFactory.cpp
@@ -4,6 +4,9 @@
 #include <Features/Scene/ParticleTestScene.h>
 
 #include <Application/Scene/GameScene.h>
+#include <Application/Scene/TitleScene.h>
+#include <Application/Scene/SelectScene.h>
+#include <Application/Scene/ResultScene.h>
 
 std::unique_ptr<BaseScene> SceneFactory::CreateScene(const std::string& _name)
 {
@@ -19,6 +22,19 @@ std::unique_ptr<BaseScene> SceneFactory::CreateScene(const std::string& _name)
     {
         return std::make_unique<GameScene>();
     }
+    else if (_name == "TitleScene")
+    {
+        return std::make_unique<TitleScene>();
+    }
+    else if (_name == "SelectScene")
+    {
+        return std::make_unique<SelectScene>();
+    }
+    else if (_name == "ResultScene")
+    {
+        return std::make_unique<ResultScene>();
+    }
+
 
     assert("Scene Not Found");
 
@@ -35,13 +51,25 @@ std::string SceneFactory::ShowDebugWindow()
     {
         return "Sample";
     }
-    if (ImGui::Button("ParticleTest"))
+   /* if (ImGui::Button("ParticleTest"))
     {
         return "ParticleTest";
-    }
+    }*/
     if (ImGui::Button("GameScene"))
     {
         return "GameScene";
+    }
+    if (ImGui::Button("TitleScene"))
+    {
+        return "TitleScene";
+    }
+    if (ImGui::Button("SelectScene"))
+    {
+        return "SelectScene";
+    }
+    if (ImGui::Button("ResultScene"))
+    {
+        return "ResultScene";
     }
 
 


### PR DESCRIPTION
RhythmProject.vcxprojおよび.vcxproj.filtersファイルに、`ResultScene`、`SelectScene`、`TitleScene`のソースおよびヘッダーファイルを追加しました。各シーンクラスには初期化、更新、描画、影描画のメソッドが実装されています。また、`SceneFactory`に新しいシーンを生成するロジックと、デバッグウィンドウにシーン選択ボタンを追加しました。