### PR TITLE
ロングノーツの判定ライン通過後の描画バグを修正

### DIFF
--- a/Application/Source/Application/Note/Note.cpp
+++ b/Application/Source/Application/Note/Note.cpp
@@ -97,6 +97,14 @@ void LongNote::Draw(const Camera* _camera)
 
     if (beforeNote_)
     {
+        // ノーツ間の差分ベクトルを計算
+        Vector3  sub = beforeNote_->GetPosition() - model_->translate_;
+        // 前のノーツが自身より奥にある場合描画しない
+        if (sub.z >= 0)
+        {
+            return;
+        }
+
         noteBridge_->Draw(_camera, 0, Vector4(0.5f, 1.0f, 0.5f, 1.0f));
     }
 }

--- a/Application/Source/Application/Note/NotesSystem.cpp
+++ b/Application/Source/Application/Note/NotesSystem.cpp
@@ -253,18 +253,12 @@ void NotesSystem::DebugWindow()
 
     if (ImGui::Button("CreateLongNote"))
     {
-        float elapseTime = stopwatch_->GetElapsedTime<float>();
-        Vector3 laneStartPosition = lane_->GetLaneStartPosition(laneIndex);
-        laneStartPosition.z = judgeLinePosition_ + (targetTime + 1.0f) * noteSpeed_;
-        laneStartPosition.y += noteSize_ / 2.0f;
-        /// デバッグ用
-        auto nextNote = std::make_shared<Note>();
-        nextNote->Initilize(laneStartPosition, noteSpeed_, targetTime + 1.0f + elapseTime, laneIndex);
+        NoteData data;
+        data.holdDuration = 1.0f; // デフォルトのホールド時間
+        data.laneIndex = laneIndex;
+        data.targetTime = targetTime + 1 + stopwatch_->GetElapsedTime<float>();
+        CreateLongNote(data);
 
-        CreateLongNote(laneIndex, noteSpeed_, targetTime + elapseTime, nextNote);
-        notes_.emplace_back(nextNote);
-        lane_->AddNote(laneIndex, nextNote);
-        //stopwatch_->Reset();
     }
 
     ImGui::PopID();


### PR DESCRIPTION
ノーツ描画の改善

`LongNote::Draw` メソッドにおいて、前のノーツとの位置関係を考慮し、描画条件を追加しました。 `NotesSystem::DebugWindow` メソッドでは、デバッグ用のノーツ作成コードを削除し、`NoteData` 構造体を使用して長ノーツを作成するように変更しました。これにより、ノーツのホールド時間やターゲット時間の設定が明確になりました。