### PR TITLE
ノートと曲のタイミング合わせ，絶対時間で。

### DIFF
--- a/Application/Resources/Data/Game/BeatMap/demo_copy.json
+++ b/Application/Resources/Data/Game/BeatMap/demo_copy.json
@@ -1,7 +1,7 @@
 {
     "title": "demo",
     "artist": "Unknown Artist",
-    "audioFilePath": "Resources/Sounds/Music/Luminous_memory_c.wav",
+    "audioFilePath": "Resources/Sounds/Music/Luminous_memory.wav",
     "bpm": 100.0,
     "offset": 0.6,
     "difficultyLevel": 3,

--- a/Application/Source/Application/BeatsManager/BeatManager.cpp
+++ b/Application/Source/Application/BeatsManager/BeatManager.cpp
@@ -37,11 +37,10 @@ void BeatManager::Update()
     if (IsNewBeat() && soundEnabled_)
     {
         // 拍に合わせて音を鳴らす
-        Debug::Log("Beat Triggered: " + std::to_string(GetNearestBeat()) + "\n");
-        //Debug::Log("Elapsed Time: " + std::to_string(stopwatch_->GetElapsedTime<float>()) + "\n");
-
-        if(soundInstance_)
+        if (soundInstance_)
+        {
             voiceInstance_ = soundInstance_->Play(volume_);
+        }
     }
 }
 
@@ -84,7 +83,7 @@ void BeatManager::Reset()
 
 float BeatManager::GetCurrentBeat() const
 {
-    float currentTime = musicVoiceInstance_->GetElapsedTime() - ( offset_);
+    float currentTime = musicVoiceInstance_->GetElapsedTime() - offset_;
     return currentTime / GetSecondsPerBeat();
 }
 

--- a/Application/Source/Application/BeatsManager/BeatManager.h
+++ b/Application/Source/Application/BeatsManager/BeatManager.h
@@ -62,7 +62,6 @@ private:
     Stopwatch* stopwatch_;
     float bpm_ = 120.0f;       // 1分あたりの拍数
     float offset_ = 0.0f;      // 開始オフセット（秒）
-    const float defaultOffset_ = 0.15f;
     int lastBeat_ = 0;        // 最後に処理した拍数
     bool playing_ = false;     // 再生中かどうか
 

--- a/Application/Source/Application/Note/Note.cpp
+++ b/Application/Source/Application/Note/Note.cpp
@@ -2,7 +2,7 @@
 
 #include <Features/LineDrawer/LineDrawer.h>
 
-void Note::Initilize(const Vector3 _position, float _speed, float _targetTime, uint32_t _laneIndex)
+void Note::Initilize(const Vector3 _position, float _targetTime, float _generatedTime, const Vector3& _targetPosition, uint32_t _laneIndex)
 {
     model_ = std::make_unique<ObjectModel>("note");
     model_->Initialize("cube/cube.obj");
@@ -14,16 +14,20 @@ void Note::Initilize(const Vector3 _position, float _speed, float _targetTime, u
     model_->scale_.z = 0.5f;
     model_->scale_.y = 0.1f;
 
-    speed_ = _speed;
-    targetTime_ = _targetTime;
     laneIndex_ = _laneIndex;
+
+    targetTime_ = _targetTime;
+    generateTime_ = _generatedTime;
+    generatePosition_ = _position;
+    targetPosition_ = _targetPosition;
 
     model_->Update();
 }
 
-void Note::Update(float _deltaTime)
+void Note::Update(float _elapseTime)
 {
-    model_->translate_ += direction * speed_ * _deltaTime;
+    float t = _elapseTime / targetTime_;
+    model_->translate_ = Vector3::Lerp(generatePosition_, targetPosition_, t);
 
     model_->Update();
 }
@@ -33,14 +37,21 @@ void Note::Draw(const Camera* _camera)
     model_->Draw(_camera, 0, color_);
 }
 
-void NomalNote::Initilize(const Vector3 _position, float _speed, float _targetTime, uint32_t _laneIndex)
+void Note::Judge()
 {
-    Note::Initilize(_position, _speed, _targetTime,_laneIndex);
+    isJudged_ = true; // 判定済みにする
+    //TODO: 音鳴らす
+    // event発行？soundInstance持たせる？
 }
 
-void NomalNote::Update(float _deltaTime)
+void NomalNote::Initilize(const Vector3 _position, float _targetTime, float _generatedTime, const Vector3& _targetPosition, uint32_t _laneIndex)
 {
-    Note::Update(_deltaTime);
+    Note::Initilize(_position, _targetTime, _generatedTime, _targetPosition, _laneIndex);
+}
+
+void NomalNote::Update(float _elapseTime)
+{
+    Note::Update(_elapseTime);
 }
 
 void NomalNote::Draw(const Camera* _camera)
@@ -56,18 +67,18 @@ LongNote::~LongNote()
     }
 }
 
-void LongNote::Initilize(const Vector3 _position, float _speed, float _targetTime, uint32_t _laneIndex)
+void LongNote::Initilize(const Vector3 _position, float _targetTime, float _generatedTime, const Vector3& _targetPosition, uint32_t _laneIndex)
 {
-    Note::Initilize(_position, _speed, _targetTime, _laneIndex);
+    Note::Initilize(_position, _targetTime, _generatedTime, _targetPosition,_laneIndex);
 
     noteBridge_ = std::make_unique<ObjectModel>("noteBridge");
     noteBridge_->Initialize("pY1x1p01Plane");// y+向きpivot(010)
     noteBridge_->useQuaternion_ = true;
 }
 
-void LongNote::Update(float _deltaTime)
+void LongNote::Update(float _elapseTime)
 {
-    Note::Update(_deltaTime);
+    Note::Update(_elapseTime);
 
 
     if (beforeNote_)

--- a/Application/Source/Application/Note/Note.h
+++ b/Application/Source/Application/Note/Note.h
@@ -13,8 +13,8 @@ public:
     Note() = default;
     virtual ~Note() = default;
 
-   virtual void Initilize(const Vector3 _position,float _speed,float _targetTime, uint32_t _laneIndex);
-   virtual void Update(float _deltaTime);
+    virtual void Initilize(const Vector3 _position, float _targetTime, float _generatedTime, const Vector3& _targetPosition, uint32_t _laneIndex);
+   virtual void Update(float _elapseTime);
    virtual void Draw(const Camera* _camera);
 
    float GetTargetTime() const { return targetTime_; }
@@ -24,20 +24,20 @@ public:
    uint32_t GetLaneIndex() const { return laneIndex_; }
 
    bool IsJudged() const { return isJudged_; }
-   virtual void Judge() { isJudged_ = true; }
+   virtual void Judge();
 
 protected:
 
     std::unique_ptr<ObjectModel> model_ = nullptr;
     Vector4 color_ = { 1,1,1,1 };
 
-    uint32_t laneIndex_ = 0;
-
-    float speed_ = 0.0f;
-
     float targetTime_ = 0.0f;
 
-    const Vector3 direction = { 0,0,-1 };
+    uint32_t laneIndex_ = 0; // レーンインデックス
+
+    float generateTime_ = 0.0f; // ノーツが生成された時間
+    Vector3 generatePosition_ = { 0,0,0 }; // ノーツが生成された位置
+    Vector3 targetPosition_ = { 0,0,0 }; // ノーツの目標位置
 
     bool isJudged_ = false;
 };
@@ -50,8 +50,8 @@ public:
     ~NomalNote() override = default;
 
 
-    void Initilize(const Vector3 _position, float _speed, float _targetTime, uint32_t _laneIndex) override;
-    void Update(float _deltaTime) override;
+    void Initilize(const Vector3 _position, float _targetTime, float _generatedTime, const Vector3& _targetPosition, uint32_t _laneIndex) override;
+    void Update(float _elapseTime) override;
     void Draw(const Camera* _camera) override;
 
 
@@ -66,8 +66,8 @@ class LongNote : public Note
 public:
     LongNote() = default;
     ~LongNote() override;
-    void Initilize(const Vector3 _position, float _speed, float _targetTime, uint32_t _laneIndex) override;
-    void Update(float _deltaTime) override;
+    void Initilize(const Vector3 _position, float _targetTime, float _generatedTime, const Vector3& _targetPosition, uint32_t _laneIndex) override;
+    void Update(float _elapseTime) override;
     void Draw(const Camera* _camera) override;
 
     virtual void Judge() override;

--- a/Application/Source/Application/Note/NotesSystem.h
+++ b/Application/Source/Application/Note/NotesSystem.h
@@ -38,7 +38,9 @@ public:
 
     void playing(bool _playing) { playing_ = _playing; }
 
-    void SetMusicSoundInstance(std::shared_ptr<SoundInstance> _musicSoundInstance) { musicSoundInstance_ = _musicSoundInstance; }
+    void SetAutoPlay(bool _autoPlay) { autoPlay_ = _autoPlay; }
+
+    void SetMusicVoiceInstance(std::shared_ptr<VoiceInstance> _voiceInstance) { musicVoiceInstance_ = _voiceInstance; }
 
     bool IsReloaded();
 
@@ -46,7 +48,6 @@ private:
 
     void CreateNormalNote(uint32_t _laneIndex, float _speed, float _targetTime);
 
-    void CreateLongNote(uint32_t _laneIndex, float _speed, float _targetTime,std::shared_ptr<Note> _beforeNote);
     void CreateLongNote(const NoteData& _noteData);
     std::shared_ptr<Note> CreateNextNoteForLongNote(uint32_t _laneIndex, float _speed, float _targetTime);
 
@@ -74,5 +75,6 @@ private:
     bool isReloaded_ = false;
 
     // 再生している音楽データ
-    std::shared_ptr<SoundInstance> musicSoundInstance_ = nullptr;
+    std::shared_ptr<VoiceInstance> musicVoiceInstance_ = nullptr;
+
 };

--- a/Application/Source/Application/Scene/GameScene.cpp
+++ b/Application/Source/Application/Scene/GameScene.cpp
@@ -10,6 +10,11 @@
 
 GameScene::~GameScene()
 {
+    if (voiceInstance_)
+    {
+        voiceInstance_->Stop();
+        voiceInstance_.reset();
+    }
 }
 
 // TODO ; やりたいこと にゅうりょく精度アップ
@@ -124,9 +129,14 @@ void GameScene::Update()
 
     if(ImGui::Button("stop"))
         beatManager_->Stop();
-    if (ImGui::Button("play"))
+    if (ImGui::Button("play##beat"))
         beatManager_->Start();
 
+
+    if (ImGui::Button("play##music"))
+    {
+        voiceInstance_->Play();
+    }
     static float bpm = 120;
     ImGui::DragFloat("BPM", &bpm, 0.1f);
     if (ImGui::Button("SetBPM"))
@@ -279,15 +289,26 @@ bool GameScene::IsComplateLoadBeatMap()
 
         // ロード完了
         Debug::Log("BeatMap Loaded Successfully\n");
+        if(soundInstance_)
+            voiceInstance_ = soundInstance_->GenerateVoiceInstance(0.3f);
+        if (voiceInstance_)
+        {
+            beatManager_->SetMusicVoiceInstance(voiceInstance_);
+            notesSystem_->SetMusicVoiceInstance(voiceInstance_);
+        }
+        else
+        {
+            Debug::Log("Error: Failed to create voice instance for sound: " + audioFilePath + "\n");
+            assert(false);
+        }
 
         // 開始する
         beatManager_->Start();
-        if (soundInstance_)
+        if (voiceInstance_)
         {
-            voiceInstance_ = soundInstance_->Play(0.3f); // ボリューム0.5で再生
-            beatManager_->SetMusicVoiceInstance(voiceInstance_);
+            voiceInstance_->Play();
         }
-        stopwatch_->Start();
+        //stopwatch_->Start();
         notesSystem_->playing(true);
 
         isBeatMapLoaded_ = true;

--- a/Application/imgui.ini
+++ b/Application/imgui.ini
@@ -16,13 +16,13 @@ DockId=0x00000006,2
 
 [Window][Debug]
 Pos=989,17
-Size=136,240
+Size=136,320
 Collapsed=0
 DockId=0x00000002,0
 
 [Window][DebugWindow]
 Pos=1127,17
-Size=135,240
+Size=135,320
 Collapsed=0
 DockId=0x00000003,0
 
@@ -44,7 +44,7 @@ Size=449,97
 Collapsed=1
 
 [Window][Light Settings]
-Pos=906,306
+Pos=906,307
 Size=346,267
 Collapsed=0
 DockId=0x00000006,3
@@ -87,7 +87,7 @@ Size=270,144
 Collapsed=0
 
 [Docking][Data]
-DockNode        ID=0x00000001 Pos=989,17 Size=273,240 Split=X
+DockNode        ID=0x00000001 Pos=989,17 Size=273,320 Split=X
   DockNode      ID=0x00000002 Parent=0x00000001 SizeRef=319,648 Selected=0x1E7E18E3
   DockNode      ID=0x00000003 Parent=0x00000001 SizeRef=317,648 Selected=0x4B6712B0
 DockNode        ID=0x00000006 Pos=906,307 Size=346,267 Selected=0x1FDCDEE6


### PR DESCRIPTION
noteのupdateでdeltaTimeをつかわず座標計算するように

BeatManager.cpp では、Update メソッドからデバッグログを削除し、音声インスタンスの再生処理を追加しました。また、Reset メソッドのオフセット計算を修正しました。 BeatManager.h では、デフォルトオフセットの定義を削除し、変数の初期化を整理しました。
Note.cpp と Note.h では、Initilize メソッドの引数を変更し、速度に関する引数を削除しました。Update メソッドの実装も線形補間を使用するように変更しました。 NotesSystem.cpp では、ノーツの生成や更新処理を改善し、生成時間や目標位置を考慮したロジックを追加しました。 GameScene.cpp では、音声インスタンスの管理を改善し、音楽再生用のボタンを追加しました。 imgui.ini では、ウィンドウのサイズや位置を調整しました。
Engine のサブプロジェクトのコミットも更新されています。