### PR TITLE
絵ぢたーで曲との同期するように。エディターレーンサイズを調整

### DIFF
--- a/Application/Source/Application/BeatMapEditor/BeatMapEditor.h
+++ b/Application/Source/Application/BeatMapEditor/BeatMapEditor.h
@@ -30,7 +30,7 @@ public:
 
 
     void Initialize();
-    void Update(float _deltaTime);
+    void Update();
     void Draw(const Camera* _camera);
     void Finalize();
 
@@ -108,8 +108,7 @@ private:
     /// <summary>
     /// エディターの状態更新
     /// </summary>
-    /// <param name="_deltaTime">deltaTime</param>
-    void UpdateEditorState(float _deltaTime);
+    void UpdateEditorState();
 
     /// <summary>
     /// パラメータからノートを検索
@@ -226,7 +225,6 @@ private:
     // エディター状態
     float currentTime_ = 0.0f; // 現在の時間
     bool isPlaying_ = false; // 再生中かどうかのフラグ
-    float playSpeed_ = 1.0f; // 再生速度
 
     // 選択状態
     std::vector<size_t> selectedNoteIndices_; // 選択中のノートインデックス

--- a/Application/Source/Application/BeatMapEditor/EditorCoordinate.h
+++ b/Application/Source/Application/BeatMapEditor/EditorCoordinate.h
@@ -94,7 +94,10 @@ public:
     /// <param name="_endTime"> 終了時間</param>
     void GetVisibleTimeRange(float& _startTime,float& _endTime) const;
 
-
+    void SetTopMargin(float _margin);
+    void SetBottomMargin(float _margin);
+    void SetVerticalMargins(float _topMargin, float _bottomMargin);
+    void SetVerticalMargins(const Vector2& _margin);
 
     // ========================================
     // グリッドライン
@@ -143,6 +146,10 @@ public:
     float GetLaneMargin() const { return laneMargin_; }
     float GetTimeZeroOffsetRatio() const { return timeZeroOffsetRatio_; }
 
+    float GetTopMargin() const { return topMargin_; }
+    float GetBottomMargin() const { return bottomMargin_; }
+
+    float GetEditAreaHeight() const { return screenSize_.y - topMargin_ - bottomMargin_; }
 
     void SetTimeZeroOffsetRatio(float _ratio);
 
@@ -160,6 +167,9 @@ private:
     float editAreaWidth_;    // 編集エリアの幅
     float laneWidth_;        // 1レーンの幅
     float laneMargin_;       // レーン間の余白
+
+    float topMargin_; // 上部マージン
+    float bottomMargin_; // 下部マージン
 
     float zoom_ ; // ズーム倍率
     float scrollOffset_; // スクロールオフセット

--- a/Application/Source/Application/Scene/TitleScene.cpp
+++ b/Application/Source/Application/Scene/TitleScene.cpp
@@ -51,7 +51,7 @@ void TitleScene::Update()
     /// ---------------------------------
     /// Application
     {
-        beatMapEditor_->Update(static_cast<float>(Time::GetDeltaTime<float>()));
+        beatMapEditor_->Update();
 
 
 
@@ -59,7 +59,7 @@ void TitleScene::Update()
     /// Application ここまで
     /// -----------------------------------
 
- 
+
     if (enableDebugCamera_)
     {
         debugCamera_.Update();

--- a/Application/imgui.ini
+++ b/Application/imgui.ini
@@ -1,6 +1,6 @@
 [Window][WindowOverViewport_11111111]
 Pos=0,0
-Size=1280,720
+Size=32,32
 Collapsed=0
 
 [Window][Debug##Default]
@@ -9,31 +9,31 @@ Size=400,400
 Collapsed=0
 
 [Window][Engine]
-Pos=1076,447
+Pos=921,445
 Size=346,267
 Collapsed=0
 DockId=0x00000006,2
 
 [Window][Debug]
-Pos=989,17
+Pos=939,-19
 Size=136,320
 Collapsed=0
 DockId=0x00000002,0
 
 [Window][DebugWindow]
-Pos=1127,17
+Pos=1077,-19
 Size=135,320
 Collapsed=0
 DockId=0x00000003,0
 
 [Window][Input]
-Pos=1076,447
+Pos=921,445
 Size=346,267
 Collapsed=0
 DockId=0x00000006,1
 
 [Window][SceneManager]
-Pos=1076,447
+Pos=921,445
 Size=346,267
 Collapsed=0
 DockId=0x00000006,0
@@ -44,14 +44,14 @@ Size=449,97
 Collapsed=1
 
 [Window][Light Settings]
-Pos=1076,447
+Pos=921,445
 Size=346,267
 Collapsed=0
 DockId=0x00000006,3
 
 [Window][TimeLine]
-Pos=297,588
-Size=983,132
+Pos=0,17
+Size=32,19
 Collapsed=0
 DockId=0x00000005,0
 
@@ -61,9 +61,9 @@ Size=120,141
 Collapsed=0
 
 [Window][Emitter]
-Size=295,720
+Pos=3,279
+Size=295,648
 Collapsed=0
-DockId=0x00000007,0
 
 [Window][TextureManager]
 Pos=23,229
@@ -76,8 +76,8 @@ Size=376,304
 Collapsed=0
 
 [Window][BeatMap Editor]
-Pos=642,0
-Size=638,720
+Pos=624,0
+Size=656,720
 Collapsed=0
 DockId=0x0000000A,0
 
@@ -87,15 +87,13 @@ Size=270,144
 Collapsed=0
 
 [Docking][Data]
-DockNode        ID=0x00000001 Pos=989,17 Size=273,320 Split=X
-  DockNode      ID=0x00000002 Parent=0x00000001 SizeRef=319,648 Selected=0x1E7E18E3
-  DockNode      ID=0x00000003 Parent=0x00000001 SizeRef=317,648 Selected=0x4B6712B0
-DockNode        ID=0x00000006 Pos=1076,447 Size=346,267 Selected=0x1FDCDEE6
-DockSpace       ID=0x08BD597D Window=0x1BBC0F80 Pos=0,0 Size=1280,720 Split=X
-  DockNode      ID=0x00000007 Parent=0x08BD597D SizeRef=295,720 Selected=0xFBFB596A
-  DockNode      ID=0x00000008 Parent=0x08BD597D SizeRef=983,720 Split=Y
-    DockNode    ID=0x00000004 Parent=0x00000008 SizeRef=1280,586 Split=X
-      DockNode  ID=0x00000009 Parent=0x00000004 SizeRef=640,720 CentralNode=1
-      DockNode  ID=0x0000000A Parent=0x00000004 SizeRef=638,720 Selected=0x7706B75A
-    DockNode    ID=0x00000005 Parent=0x00000008 SizeRef=1280,132 Selected=0x42899545
+DockNode      ID=0x00000001 Pos=939,-19 Size=273,320 Split=X
+  DockNode    ID=0x00000002 Parent=0x00000001 SizeRef=319,648 Selected=0x1E7E18E3
+  DockNode    ID=0x00000003 Parent=0x00000001 SizeRef=317,648 Selected=0x4B6712B0
+DockNode      ID=0x00000006 Pos=921,445 Size=346,267 Selected=0xAC437A35
+DockSpace     ID=0x08BD597D Window=0x1BBC0F80 Pos=0,0 Size=32,32 Split=Y
+  DockNode    ID=0x00000004 Parent=0x08BD597D SizeRef=1280,586 Split=X
+    DockNode  ID=0x00000009 Parent=0x00000004 SizeRef=622,720 CentralNode=1
+    DockNode  ID=0x0000000A Parent=0x00000004 SizeRef=656,720 Selected=0x7706B75A
+  DockNode    ID=0x00000005 Parent=0x08BD597D SizeRef=1280,132 Selected=0x42899545
 


### PR DESCRIPTION
描画時の不具合を修正

エディターの初期化と描画処理の改善

BeatMapEditor.cppのInitialize関数で画面サイズを1280.0f / 4.0fに変更し、時間のオフセット比を0.1fに設定しました。レーンのサイズと位置もエディットエリアの高さと下部マージンに基づいて調整しました。

Update関数とUpdateEditorState関数を引数なしに変更し、再生中の時間を音楽の経過時間に基づいて更新するようにしました。DrawNotes関数では、ノートが画面内にあるかをチェックし、ホールド時間が可視範囲内にある場合のみ描画するように条件を追加しました。

HandleInput関数にESCキーで選択をクリアする処理を追加し、EditorCoordinate.cppでは上下マージンを設定する新しい関数を追加しました。imgui.iniでは、ウィンドウのサイズや位置を変更し、BeatMap Editorのサイズを小さくしました。