### PR TITLE
ライブマッピング機能を追加

### DIFF
--- a/Application/RhythmProject.vcxproj
+++ b/Application/RhythmProject.vcxproj
@@ -95,6 +95,7 @@
     <ClCompile Include="main.cpp" />
     <ClCompile Include="Source\Application\BeatMapEditor\BeatMapEditor.cpp" />
     <ClCompile Include="Source\Application\BeatMapEditor\EditorCoordinate.cpp" />
+    <ClCompile Include="Source\Application\BeatMapEditor\LiveMapping\LiveMapping.cpp" />
     <ClCompile Include="Source\Application\BeatMapLoader\BeatMapLoader.cpp" />
     <ClCompile Include="Source\Application\BeatsManager\BeatManager.cpp" />
     <ClCompile Include="Source\Application\Effects\LaneEffect\LaneEffect.cpp" />
@@ -125,6 +126,7 @@
   <ItemGroup>
     <ClInclude Include="Source\Application\BeatMapEditor\BeatMapEditor.h" />
     <ClInclude Include="Source\Application\BeatMapEditor\EditorCoordinate.h" />
+    <ClInclude Include="Source\Application\BeatMapEditor\LiveMapping\LiveMapping.h" />
     <ClInclude Include="Source\Application\BeatMapLoader\BeatMapData.h" />
     <ClInclude Include="Source\Application\BeatMapLoader\BeatMapLoader.h" />
     <ClInclude Include="Source\Application\BeatsManager\BeatManager.h" />

--- a/Application/RhythmProject.vcxproj.filters
+++ b/Application/RhythmProject.vcxproj.filters
@@ -55,6 +55,9 @@
     <Filter Include="Application\BeatMapEditor">
       <UniqueIdentifier>{42d12039-f238-4928-b0c9-82f58e97bf2d}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Application\BeatMapEditor\LiveMapping">
+      <UniqueIdentifier>{83c39ab7-9b96-4399-95d0-f76404b6a61d}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />
@@ -126,6 +129,9 @@
     </ClCompile>
     <ClCompile Include="Source\Application\BeatMapEditor\EditorCoordinate.cpp">
       <Filter>Application\BeatMapEditor</Filter>
+    </ClCompile>
+    <ClCompile Include="Source\Application\BeatMapEditor\LiveMapping\LiveMapping.cpp">
+      <Filter>Application\BeatMapEditor\LiveMapping</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -215,6 +221,9 @@
     </ClInclude>
     <ClInclude Include="Source\Application\BeatMapEditor\BeatMapEditor.h">
       <Filter>Application\BeatMapEditor</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\Application\BeatMapEditor\LiveMapping\LiveMapping.h">
+      <Filter>Application\BeatMapEditor\LiveMapping</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Application/Source/Application/BeatMapEditor/BeatMapEditor.h
+++ b/Application/Source/Application/BeatMapEditor/BeatMapEditor.h
@@ -10,6 +10,7 @@
 #include <Application/BeatMapEditor/EditorCoordinate.h>
 #include <Application/BeatMapLoader/BeatMapData.h>
 
+#include <Application/BeatMapEditor/LiveMapping/LiveMapping.h>
 
 #include <string>
 #include <cstdint>
@@ -95,6 +96,10 @@ private:
     /// <param name="_deltaTime">新しい時間</param>
     void MoveSelectedNote(float _newTime);
 
+    /// <summary>
+    /// ライブマッピングを適用
+    /// </summary>
+    void ApplyLiveMapping();
 
     ///---------------------
     /// 内部処理関連
@@ -265,6 +270,7 @@ private:
         PlaceNormalNote,
         PlaceLongNote,
         Delete,
+        LiveMapping,
 
         Count // モードの数
     };
@@ -274,6 +280,7 @@ private:
     float longNoteStartTime_ = 0.0f; // ロングノートの開始時間
     int32_t longNoteStartLane_ = 0; // ロングノートの開始レーン
 
+    LiveMapping liveMapping_;
 
     // 配置プレビュー
     std::unique_ptr<UISprite> previewNoteSprite_; // ノート配置プレビュー用のスプライト

--- a/Application/Source/Application/BeatMapEditor/LiveMapping/LiveMapping.cpp
+++ b/Application/Source/Application/BeatMapEditor/LiveMapping/LiveMapping.cpp
@@ -1,0 +1,74 @@
+#include "LiveMapping.h"
+
+void LiveMapping::Initialize(int32_t _laneCount)
+{
+    input_ = Input::GetInstance(); // 入力管理クラスのインスタンスを取得
+
+    // レーン数に応じてキーコードのリストを初期化
+    laneKeyBindings_.resize(_laneCount, 0); // 初期値は0（未設定）
+    //デフォルトを設定
+    SetDefaultKeyBindings(_laneCount);
+
+    // マッピングデータの初期化
+    mappingData_.clear();
+    mappingData_.reserve(100); // 初期容量を設定（必要に応じて調整可能）
+
+}
+
+void LiveMapping::Update(float _elapsedTime)
+{
+    for (size_t i = 0; i < laneKeyBindings_.size(); ++i)
+    {
+        // キーが押されたかチェック
+        if (input_->IsKeyTriggered(laneKeyBindings_[i]))
+        {
+            // マッピングデータに追加
+            mappingData_.emplace_back(i, _elapsedTime);
+        }
+    }
+}
+
+void LiveMapping::ResetMappingData()
+{
+    mappingData_.clear(); // マッピングデータをクリア
+}
+
+void LiveMapping::SetLaneKeyBinding(int32_t _laneIndex, uint8_t _keyCode)
+{
+    // レーンインデックスが範囲内かチェック
+    if (_laneIndex < 0 || _laneIndex >= static_cast<int32_t>(laneKeyBindings_.size()))
+    {
+        return;
+    }
+
+    laneKeyBindings_[_laneIndex] = _keyCode; // キーコードを設定
+}
+
+void LiveMapping::SetDefaultKeyBindings(int32_t _laneIndex)
+{
+     // 使わないかもだけど念のため複数パターン用意しておく
+    if (_laneIndex == 4)
+    {
+        laneKeyBindings_[0] = DIK_D;
+        laneKeyBindings_[1] = DIK_F;
+        laneKeyBindings_[2] = DIK_J;
+        laneKeyBindings_[3] = DIK_K;
+    }
+    if (_laneIndex == 5)
+    {
+        laneKeyBindings_[0] = DIK_D;
+        laneKeyBindings_[1] = DIK_F;
+        laneKeyBindings_[2] = DIK_SPACE;
+        laneKeyBindings_[3] = DIK_J;
+        laneKeyBindings_[4] = DIK_K;
+    }
+    if (_laneIndex == 6)
+    {
+        laneKeyBindings_[0] = DIK_S;
+        laneKeyBindings_[1] = DIK_D;
+        laneKeyBindings_[2] = DIK_F;
+        laneKeyBindings_[3] = DIK_J;
+        laneKeyBindings_[4] = DIK_K;
+        laneKeyBindings_[5] = DIK_L;
+    }
+}

--- a/Application/Source/Application/BeatMapEditor/LiveMapping/LiveMapping.h
+++ b/Application/Source/Application/BeatMapEditor/LiveMapping/LiveMapping.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <System/Input/Input.h>
+
+
+#include <cstdint>
+#include <vector>
+
+struct MappingData
+{
+    int32_t laneIndex; // レーンインデックス
+    float targetTime; // ターゲット時間
+
+    MappingData(int32_t _laneIndex = -1, float _targetTime = -1.0f)
+        : laneIndex(_laneIndex), targetTime(_targetTime) {
+    }
+
+};
+
+class LiveMapping
+{
+public:
+
+    LiveMapping() = default;
+    ~LiveMapping() = default;
+
+    /// <summary>
+    /// 初期化処理
+    /// </summary>
+    void Initialize(int32_t _laneCount);
+
+    /// <summary>
+    /// 更新処理
+    /// </summary>
+    /// <param name="_elapsedTime">曲の経過時間</param>
+    void Update(float _elapsedTime);
+
+    /// <summary>
+    /// マッピングデータを取得
+    /// </summary>
+    /// <returns>マッピングデータのリスト</returns>
+    std::vector<MappingData>& GetMappingData() { return mappingData_; }
+
+    /// <summary>
+    /// マッピングデータをリセット
+    /// </summary>
+    void ResetMappingData();
+
+    /// <summary>
+    /// レーンのキー入力バインディングを設定
+    /// </summary>
+    /// <param name="_laneIndex">レーン番号</param>
+    /// <param name="_keyCode">キーコード (DIK_Aなど)</param>
+    void SetLaneKeyBinding(int32_t _laneIndex, uint8_t _keyCode);
+
+private:
+
+    /// <summary>
+    /// デフォルトのキー入力バインディングを設定
+    /// </summary>
+    void SetDefaultKeyBindings(int32_t _laneIndex);
+
+private:
+    Input* input_ = nullptr; // 入力管理クラスへのポインタ
+
+    std::vector<uint8_t> laneKeyBindings_; // レーンごとのキー入力バインディング
+
+    std::vector<MappingData> mappingData_; // マッピングデータのリスト
+
+};

--- a/Application/imgui.ini
+++ b/Application/imgui.ini
@@ -9,31 +9,31 @@ Size=400,400
 Collapsed=0
 
 [Window][Engine]
-Pos=921,445
+Pos=931,444
 Size=346,267
 Collapsed=0
 DockId=0x00000006,2
 
 [Window][Debug]
-Pos=939,-19
+Pos=999,14
 Size=136,320
 Collapsed=0
 DockId=0x00000002,0
 
 [Window][DebugWindow]
-Pos=1077,-19
+Pos=1137,14
 Size=135,320
 Collapsed=0
 DockId=0x00000003,0
 
 [Window][Input]
-Pos=921,445
+Pos=931,444
 Size=346,267
 Collapsed=0
 DockId=0x00000006,1
 
 [Window][SceneManager]
-Pos=921,445
+Pos=931,444
 Size=346,267
 Collapsed=0
 DockId=0x00000006,0
@@ -44,7 +44,7 @@ Size=449,97
 Collapsed=1
 
 [Window][Light Settings]
-Pos=921,445
+Pos=931,444
 Size=346,267
 Collapsed=0
 DockId=0x00000006,3
@@ -76,8 +76,8 @@ Size=376,304
 Collapsed=0
 
 [Window][BeatMap Editor]
-Pos=624,0
-Size=656,720
+Pos=17,0
+Size=15,32
 Collapsed=0
 DockId=0x0000000A,0
 
@@ -87,10 +87,10 @@ Size=270,144
 Collapsed=0
 
 [Docking][Data]
-DockNode      ID=0x00000001 Pos=939,-19 Size=273,320 Split=X
+DockNode      ID=0x00000001 Pos=999,14 Size=273,320 Split=X
   DockNode    ID=0x00000002 Parent=0x00000001 SizeRef=319,648 Selected=0x1E7E18E3
   DockNode    ID=0x00000003 Parent=0x00000001 SizeRef=317,648 Selected=0x4B6712B0
-DockNode      ID=0x00000006 Pos=921,445 Size=346,267 Selected=0xAC437A35
+DockNode      ID=0x00000006 Pos=931,444 Size=346,267 Selected=0x1FDCDEE6
 DockSpace     ID=0x08BD597D Window=0x1BBC0F80 Pos=0,0 Size=32,32 Split=Y
   DockNode    ID=0x00000004 Parent=0x08BD597D SizeRef=1280,586 Split=X
     DockNode  ID=0x00000009 Parent=0x00000004 SizeRef=622,720 CentralNode=1


### PR DESCRIPTION
RhythmProject.vcxprojに`LiveMapping.cpp`と`LiveMapping.h`を追加し、関連するフィルターを設定しました。 `BeatMapEditor.cpp`にライブマッピング機能を適用するボタンを追加し、データリセット機能とモード切り替えを実装しました。 `BeatMapEditor.h`にライブマッピングメソッドを追加し、エディターモードにライブマッピングを追加しました。 `LiveMapping.cpp`と`LiveMapping.h`には、初期化、更新、リセット、キー入力バインディングのメソッドを実装しました。 `imgui.ini`のウィンドウサイズを変更し、エンジンのサブプロジェクトのコミットIDを更新しました。