### PR TITLE
範囲選択機能の追加

### DIFF
--- a/Application/Source/Application/BeatMapEditor/BeatMapEditor.h
+++ b/Application/Source/Application/BeatMapEditor/BeatMapEditor.h
@@ -144,6 +144,11 @@ private:
 
 
     /// <summary>
+    /// 範囲選択エリアのチェック
+    /// </summary>
+    void CheckSelectionArea(); // 範囲選択エリアのチェック
+
+    /// <summary>
     /// 状態のリセット
     /// </summary>
     void Reset();
@@ -206,6 +211,11 @@ private:
     /// 配置プレビューのノートを描画
     /// </summary>
     void DrawPreviewNote();
+
+    /// <summary>
+    /// 範囲選択エリアを描画
+    /// </summary>
+    void DrawSelectionArea();
 
 private:
 
@@ -287,6 +297,18 @@ private:
     std::unique_ptr<UISprite> previewBridgeSprite_; // ロングノート配置プレビュー用のスプライト
     std::unique_ptr<UISprite> previewHoldEndSprite_; // ロングノート終端配置プレビュー用のスプライト
     float previewAlpha_ = 0.5f; // プレビューの透明度
+
+
+    /// 範囲選択のための変数たち
+    // ドラッグしているか
+    bool isDragging_ = false;
+    // ドラッグ開始座標
+    Vector2 dragStartPosition_ = { 0.0f, 0.0f };
+    // ドラッグ終了座標
+    Vector2 dragEndPosition_ = { 0.0f, 0.0f };
+    // 範囲選択をしたか
+    bool isRangeSelected_ = false; // 範囲選択をしたかどうかのフラグ
+    std::unique_ptr<UISprite> areaSelectionSprite_; // 範囲選択用のスプライト
 
 
     std::unique_ptr<UISprite> dummy_editArea_; // エディターエリア マウス判定用

--- a/Application/Source/Application/BeatMapEditor/LiveMapping/LiveMapping.cpp
+++ b/Application/Source/Application/BeatMapEditor/LiveMapping/LiveMapping.cpp
@@ -17,7 +17,7 @@ void LiveMapping::Initialize(int32_t _laneCount)
 
 void LiveMapping::Update(float _elapsedTime)
 {
-    for (size_t i = 0; i < laneKeyBindings_.size(); ++i)
+    for (uint32_t i = 0; i < laneKeyBindings_.size(); ++i)
     {
         // キーが押されたかチェック
         if (input_->IsKeyTriggered(laneKeyBindings_[i]))

--- a/Application/imgui.ini
+++ b/Application/imgui.ini
@@ -1,6 +1,6 @@
 [Window][WindowOverViewport_11111111]
 Pos=0,0
-Size=32,32
+Size=1280,720
 Collapsed=0
 
 [Window][Debug##Default]
@@ -76,8 +76,8 @@ Size=376,304
 Collapsed=0
 
 [Window][BeatMap Editor]
-Pos=17,0
-Size=15,32
+Pos=624,0
+Size=656,720
 Collapsed=0
 DockId=0x0000000A,0
 
@@ -91,7 +91,7 @@ DockNode        ID=0x00000001 Pos=939,14 Size=273,320 Split=X
   DockNode      ID=0x00000002 Parent=0x00000001 SizeRef=319,648 Selected=0x1E7E18E3
   DockNode      ID=0x00000003 Parent=0x00000001 SizeRef=317,648 Selected=0x4B6712B0
 DockNode        ID=0x00000006 Pos=931,444 Size=346,267 Selected=0x1FDCDEE6
-DockSpace       ID=0x08BD597D Window=0x1BBC0F80 Pos=0,0 Size=32,32 Split=X
+DockSpace       ID=0x08BD597D Window=0x1BBC0F80 Pos=0,0 Size=1280,720 Split=X
   DockNode      ID=0x00000007 Parent=0x08BD597D SizeRef=268,720 Selected=0xFBFB596A
   DockNode      ID=0x00000008 Parent=0x08BD597D SizeRef=1010,720 Split=Y
     DockNode    ID=0x00000004 Parent=0x00000008 SizeRef=1280,586 Split=X


### PR DESCRIPTION
BeatMapEditor.cppに範囲選択用のスプライトを初期化するコードを追加し、選択エリアの描画機能を実装しました。`SelectNote`関数に範囲選択の条件を追加し、`ClearSelection`関数で範囲選択フラグをリセットする処理を追加しました。`HandleInput`関数ではドラッグ操作による範囲選択の処理を実装し、`CheckSelectionArea`関数を新たに追加しました。また、`BeatMapEditor.h`に新しい関数の宣言を追加しました。