### PR TITLE
エディターにビートマネージャーを追加

### DIFF
--- a/Application/Source/Application/BeatMapEditor/BeatMapEditor.h
+++ b/Application/Source/Application/BeatMapEditor/BeatMapEditor.h
@@ -9,6 +9,7 @@
 
 #include <Application/BeatMapEditor/EditorCoordinate.h>
 #include <Application/BeatMapLoader/BeatMapData.h>
+#include <Application/BeatsManager/BeatManager.h>
 
 #include <Application/BeatMapEditor/LiveMapping/LiveMapping.h>
 
@@ -225,6 +226,9 @@ private:
     Camera for2dCamera_; // 2D描画用のカメラ
 
     BeatMapLoader* beatMapLoader_ = nullptr;
+    std::unique_ptr<BeatManager> beatManager_ = nullptr;
+    bool enableBeats_ = false;
+
     EditorCoordinate editorCoordinate_;
 
     // 譜面データ

--- a/Application/imgui.ini
+++ b/Application/imgui.ini
@@ -1,6 +1,6 @@
 [Window][WindowOverViewport_11111111]
 Pos=0,0
-Size=1280,720
+Size=32,32
 Collapsed=0
 
 [Window][Debug##Default]
@@ -15,13 +15,13 @@ Collapsed=0
 DockId=0x00000006,2
 
 [Window][Debug]
-Pos=939,14
+Pos=972,26
 Size=136,320
 Collapsed=0
 DockId=0x00000002,0
 
 [Window][DebugWindow]
-Pos=1077,14
+Pos=1110,26
 Size=135,320
 Collapsed=0
 DockId=0x00000003,0
@@ -76,8 +76,8 @@ Size=376,304
 Collapsed=0
 
 [Window][BeatMap Editor]
-Pos=624,0
-Size=656,720
+Pos=17,0
+Size=15,32
 Collapsed=0
 DockId=0x0000000A,0
 
@@ -87,11 +87,11 @@ Size=270,144
 Collapsed=0
 
 [Docking][Data]
-DockNode        ID=0x00000001 Pos=939,14 Size=273,320 Split=X
+DockNode        ID=0x00000001 Pos=972,26 Size=273,320 Split=X
   DockNode      ID=0x00000002 Parent=0x00000001 SizeRef=319,648 Selected=0x1E7E18E3
   DockNode      ID=0x00000003 Parent=0x00000001 SizeRef=317,648 Selected=0x4B6712B0
 DockNode        ID=0x00000006 Pos=931,444 Size=346,267 Selected=0x1FDCDEE6
-DockSpace       ID=0x08BD597D Window=0x1BBC0F80 Pos=0,0 Size=1280,720 Split=X
+DockSpace       ID=0x08BD597D Window=0x1BBC0F80 Pos=0,0 Size=32,32 Split=X
   DockNode      ID=0x00000007 Parent=0x08BD597D SizeRef=268,720 Selected=0xFBFB596A
   DockNode      ID=0x00000008 Parent=0x08BD597D SizeRef=1010,720 Split=Y
     DockNode    ID=0x00000004 Parent=0x00000008 SizeRef=1280,586 Split=X


### PR DESCRIPTION
`BeatMapEditor.cpp`にビートマネージャーを追加し、音楽の再生、BPM設定、ビートの有効化機能を実装しました。UIにビートの有効化を切り替えるチェックボックスを追加し、ユーザーが設定を簡単に変更できるようにしました。

`BeatMapEditor.h`では、`BeatManager`のインクルードと`beatManager_`メンバー変数を追加しました。これにより、ビートマネージャーのインスタンスを保持し、音楽の再生やビートの管理が可能になります。