### PR TITLE
譜面ロード完了から音楽再生までの猶予時間を設けるようにした。

### DIFF
--- a/Application/Source/Application/Note/NotesSystem.h
+++ b/Application/Source/Application/Note/NotesSystem.h
@@ -20,7 +20,7 @@ public:
     NotesSystem(Lane* _lane);
     ~NotesSystem();
 
-    void Initialize(float _noteSpeed, float _noteSize);
+    void Initialize(float _noteSpeed, float _noteSize, float _startOffsetTime = 2.0f);
     void Update(float _deltaTime);
     void DrawNotes(const Camera* _camera);
 
@@ -44,6 +44,8 @@ public:
 
     bool IsReloaded();
 
+    void Start() { isStarted_ = true; }
+
 private:
 
     void CreateNormalNote(uint32_t _laneIndex, float _speed, float _targetTime);
@@ -60,6 +62,10 @@ private:
     float judgeLinePosition_ = 0.0f;
     // miss判定で消えるまでの猶予座標
     float missJudgeThreshold_ = 3.0f;
+
+    bool isStarted_ = false; // ゲーム開始オフセット時間を超えたかどうか
+    float waitTimer_ = 0.0f; // ゲーム開始オフセット時間を超えるまでのタイマ
+    float startOffsetTime_ = 0.0f; // ゲーム開始オフセット時間
 
     Lane* lane_ = nullptr;
     std::list<std::shared_ptr<Note>> notes_;

--- a/Application/Source/Application/Scene/GameScene.h
+++ b/Application/Source/Application/Scene/GameScene.h
@@ -43,6 +43,12 @@ private:
     /// <returns> 読み込み完了 or 読み込み済みなら true </returns>
     bool IsComplateLoadBeatMap();
 
+    /// <summary>
+    /// ゲーム開始オフセット処理の更新
+    /// </summary>
+    void UpdateGameStartOffset();
+
+
     // シーン関連
     Camera SceneCamera_ = {};
     DebugCamera debugCamera_ = {};
@@ -71,8 +77,15 @@ private:
     std::future<bool> beatMapLoadFuture_ = {};
 
     bool isBeatMapLoaded_ = false;
-    int frameCount_ = 0;
+
+    bool isWatingForStart_ = false;
+    float gameStartOffset_ = 2.0f;
+    float waitTimer_ = 0.0f;
 
     std::shared_ptr<SoundInstance> soundInstance_ = nullptr;
     std::shared_ptr<VoiceInstance> voiceInstance_ = nullptr;
+
+    void ImGui();
+
+
 };


### PR DESCRIPTION
ゲーム開始オフセット処理の追加と最適化

`NotesSystem`において、`Initialize`メソッドが`_startOffsetTime`引数を受け取るように変更され、`Update`メソッドに待機タイマーの更新ロジックが追加されました。

`GameScene`では、ゲーム開始オフセットの処理が追加され、`UpdateGameStartOffset`メソッドが実装されました。デバッグ情報の表示が整理され、ボタン操作に関する処理も追加されました。`GameScene.h`においては、関連するメンバー変数とメソッドの宣言が追加されました。