### PR TITLE
レーンの描画とリスタートの修正

### DIFF
--- a/Application/Source/Application/Core/GameCore.h
+++ b/Application/Source/Application/Core/GameCore.h
@@ -58,6 +58,12 @@ public:
     /// 開始
     /// </summary>
     void Start() { isWaitingForStart_ = false; }
+
+    /// <summary>
+    /// リスタート
+    /// </summary>
+    void Restart(std::shared_ptr<VoiceInstance> _voiceInstance);
+
 private:
 
     void JudgeNotes(const std::vector<InputDate>& _inputData);
@@ -68,6 +74,8 @@ private:
     /// <param name="_beatMapData">譜面データ</param>
     void ParseBeatMapData(const BeatMapData& _beatMapData);
 
+    void CreateBeatMapNotes();
+
 private:
 
     // note
@@ -75,6 +83,8 @@ private:
     float noteSpeed_ = 30.0f; // ノーツの移動速度
     int32_t laneCount_ = 4; // レーンの数
     std::vector<std::unique_ptr<Lane>> lanes_; // レーンのリスト
+    std::vector<std::list<NoteData>> notesPerLane_; // レーンごとのノートデータリスト
+
     // judge
     std::unique_ptr<NoteJudge> noteJudge_; // ノーツの判定を行うクラス
     std::unique_ptr<JudgeResult> judgeResult_; // 判定結果を保持するクラス

--- a/Application/Source/Application/Lane/Lane.cpp
+++ b/Application/Source/Application/Lane/Lane.cpp
@@ -20,12 +20,14 @@ void Lane::Initialize(const std::list<NoteData>& _noteDataList, int32_t _laneInd
     static float laneLeftEdge = basePosition.x - (totalWidth_ / 2.0f);
     static float laneTopEdge = basePosition.z + laneLength_;
 
-    startPosition_.x = laneLeftEdge + (static_cast<float>(_laneIndex) * laneWidth_);
+    startPosition_.x = laneLeftEdge + (static_cast<float>(_laneIndex) * laneWidth_) + laneWidth_ / 2.0f;
     startPosition_.y = 0.0f; // 高さは0
     startPosition_.z = laneTopEdge; // 奥
 
     endPosition_ = startPosition_;
     endPosition_.z -= laneLength_; // レーンの終了位置は開始位置からレーンの長さだけ手前
+
+    CreateLaneModel();
 
     // ノーツを生成
     CreateNotes(_noteDataList, _laneIndex, _judgeLine, _speed, _startOffsetTime);
@@ -52,6 +54,10 @@ void Lane::Update(float _elapseTime, float _speed)
 void Lane::Draw(const Camera* _camera) const
 {
     //  TODO レーン描画
+    if (laneModel_)
+    {
+        laneModel_->Draw(_camera, { 0.5f,0.5f,0.5f,0.7f });
+    }
 
     for (const auto& note : notes_)
     {
@@ -130,5 +136,14 @@ void Lane::CreateNotes(const std::list<NoteData>& _noteDataList, int32_t _laneIn
             }
         }
     }
+}
 
+void Lane::CreateLaneModel()
+{
+    laneModel_ = std::make_unique<ObjectModel>("Lane");
+    laneModel_->Initialize("pY1x1p01Plane");
+    laneModel_->scale_ = Vector3(laneWidth_ - 0.1f, 1.0f, laneLength_); // レーンの幅と長さを設定
+    laneModel_->translate_ = startPosition_;
+    laneModel_->translate_.y -= 0.001f; // zファイティング対策で少し下げる
+    laneModel_->Update();
 }

--- a/Application/Source/Application/Lane/Lane.h
+++ b/Application/Source/Application/Lane/Lane.h
@@ -72,8 +72,10 @@ private: // 内部処理用関数たち
     /// </summary>
     void CreateNotes(const std::list<NoteData>& _noteDataList, int32_t _laneIndex, float _judgeLine, float  _speed, float _startOffsetTime);
 
-
+    void CreateLaneModel();
 private:
+
+    std::unique_ptr<ObjectModel> laneModel_ = nullptr; // レーンのモデル
 
     std::list<std::shared_ptr<Note>> notes_; // レーンにあるノーツ
 

--- a/Application/Source/Application/Note/Judge/NoteJudge.cpp
+++ b/Application/Source/Application/Note/Judge/NoteJudge.cpp
@@ -50,8 +50,8 @@ void NoteJudge::DrawJudgeLine()
         // 判定ラインを描画
         float position = timingThresholds_[i] * speed_ + position_;
 
-        Vector3 start = { -halfWidth, 0,  position };
-        Vector3 end = { halfWidth, 0, position };
+        Vector3 start = { -halfWidth, 0.01f,  position };
+        Vector3 end = { halfWidth, 0.01f, position };
 
         LineDrawer::GetInstance()->RegisterPoint(start, end, Vector4(1, 1, 0, 1));
     }

--- a/Application/Source/Application/Scene/GameScene.cpp
+++ b/Application/Source/Application/Scene/GameScene.cpp
@@ -293,11 +293,10 @@ void GameScene::ImGui()
 
     if (input_->IsKeyTriggered(DIK_R))
     {
-        beatManager_->SetOffset(offset);
         voiceInstance_->Stop();
         voiceInstance_.reset();
         voiceInstance_ = soundInstance_->Play(volume); // ボリュームとオフセットを設定して再生
-        gameCore_->SetMusicVoiceInstance(voiceInstance_);
+        gameCore_->Restart(voiceInstance_); // ゲームコアに音声インスタンスを設定
         gameInputManager_->SetMusicVoiceInstance(voiceInstance_);
         beatManager_->Reset();
     }


### PR DESCRIPTION
ノートデータ管理の改善とリスタート機能追加

`GameCore` クラスに `notesPerLane_` メンバー変数を追加し、ノートデータの管理を強化しました。`ParseBeatMapData` メソッドを修正し、エラー処理やソート処理を新しいメンバー変数に対応させました。また、ノートの初期化を行う `CreateBeatMapNotes` メソッドと、音声インスタンスを設定する `Restart` メソッドを追加しました。

`Lane` クラスでは、`Initialize` メソッドの開始位置計算を修正し、レーンのモデルを作成する `CreateLaneModel` メソッドを追加しました。これにより、レーンの見た目が改善されました。

`NoteJudge` クラスでは、判定ラインの描画位置を微調整し、視覚的な改善を行いました。

`GameScene` クラスでは、リスタート処理を改善し、音声インスタンス設定時に `Restart` メソッドを呼び出すようにしました。これにより、ゲームの状態リセット処理が一貫性を持つようになりました。