### PR TITLE
BPMとオフセットを変更できるように

### DIFF
--- a/Application/Resources/Data/Game/BeatMap/demo1.json
+++ b/Application/Resources/Data/Game/BeatMap/demo1.json
@@ -1,8 +1,8 @@
 {
     "artist": "unknown",
-    "audioFilePath": "",
-    "bpm": 120.0,
+    "audioFilePath": "Resources/Sounds/Music/demo_Music.wav",
+    "bpm": 144.0,
     "difficultyLevel": 0,
-    "offset": 0.0,
+    "offset": 0.2199999988079071,
     "title": "demo1"
 }

--- a/Application/Source/Application/BeatMapEditor/BeatMapEditor.cpp
+++ b/Application/Source/Application/BeatMapEditor/BeatMapEditor.cpp
@@ -439,6 +439,7 @@ void BeatMapEditor::DrawUI()
         if (ImGui::Button("Play"))
         {
             isPlaying_ = !isPlaying_; // 再生/一時停止の切り替え
+            PlayMusic();
         }
         ImGui::SameLine();
         if (ImGui::Button("Stop"))
@@ -457,6 +458,12 @@ void BeatMapEditor::DrawUI()
         ImGui::RadioButton("1/16", &snapIntervalIndex, 4);
         snapInterval_ = 1.0f / std::powf(2.0f, static_cast<float>(snapIntervalIndex));
 
+        if(ImGui::DragFloat("music Offset", &currentBeatMapData_.offset, 0.001f)) // 音楽のオフセットを調整するフィールド
+            beatManager_->SetOffset(currentBeatMapData_.offset);
+        if(ImGui::DragFloat("BPM", &currentBeatMapData_.bpm, 0.1f)) // BPMの入力フィールド
+            beatManager_->SetBPM(currentBeatMapData_.bpm);
+
+      
         ImGui::SeparatorText("Music Control");
         if (ImGui::Button("Load Music"))
         {
@@ -1162,7 +1169,8 @@ void BeatMapEditor::UpdateEditorState()
             beatManager_->SetEnableSound(enableBeats_);
             beatManager_->Update();
         }
-        currentTime_ = musicVoiceInstance_->GetElapsedTime();
+        if(musicVoiceInstance_)
+            currentTime_ = musicVoiceInstance_->GetElapsedTime();
 
         editorCoordinate_.SetScrollOffset(currentTime_);
     }

--- a/Application/imgui.ini
+++ b/Application/imgui.ini
@@ -1,6 +1,6 @@
 [Window][WindowOverViewport_11111111]
 Pos=0,0
-Size=1280,720
+Size=32,32
 Collapsed=0
 
 [Window][Debug##Default]
@@ -76,13 +76,13 @@ Size=376,304
 Collapsed=0
 
 [Window][BeatMap Editor]
-Pos=620,4
+Pos=620,5
 Size=664,713
 Collapsed=0
 
 [Window][Save Confirmation]
 Pos=360,250
-Size=270,144
+Size=570,144
 Collapsed=0
 
 [Window][Dear ImGui Demo]
@@ -95,7 +95,7 @@ DockNode      ID=0x00000001 Pos=1001,14 Size=273,320 Split=X
   DockNode    ID=0x00000002 Parent=0x00000001 SizeRef=319,648 Selected=0x1E7E18E3
   DockNode    ID=0x00000003 Parent=0x00000001 SizeRef=317,648 Selected=0x4B6712B0
 DockNode      ID=0x00000006 Pos=938,360 Size=346,267 Selected=0x1FDCDEE6
-DockSpace     ID=0x08BD597D Window=0x1BBC0F80 Pos=0,0 Size=1280,720 Split=X
+DockSpace     ID=0x08BD597D Window=0x1BBC0F80 Pos=0,0 Size=32,32 Split=X
   DockNode    ID=0x00000007 Parent=0x08BD597D SizeRef=268,720 Selected=0xFBFB596A
   DockNode    ID=0x00000008 Parent=0x08BD597D SizeRef=1010,720 Split=Y
     DockNode  ID=0x00000004 Parent=0x00000008 SizeRef=1280,586 CentralNode=1


### PR DESCRIPTION
音楽機能の追加と設定ファイルの更新

demo1.jsonで音声ファイルパスとBPMを更新し、オフセットを追加しました。新しい音声ファイルdemo_Music.wavを追加しました。BeatMapEditor.cppでは、音楽再生ボタンとオフセット・BPM調整フィールドを追加し、UpdateEditorState関数を修正しました。imgui.iniではウィンドウのサイズと位置を調整し、ドッキングノードの設定を変更しました。