### PR TITLE
BPMカウンター機能を追加

### DIFF
--- a/Application/RhythmProject.vcxproj
+++ b/Application/RhythmProject.vcxproj
@@ -94,6 +94,7 @@
   <ItemGroup>
     <ClCompile Include="main.cpp" />
     <ClCompile Include="Source\Application\BeatMapEditor\BeatMapEditor.cpp" />
+    <ClCompile Include="Source\Application\BeatMapEditor\BPMCounter\TapBPMCounter.cpp" />
     <ClCompile Include="Source\Application\BeatMapEditor\EditorCoordinate.cpp" />
     <ClCompile Include="Source\Application\BeatMapEditor\LiveMapping\LiveMapping.cpp" />
     <ClCompile Include="Source\Application\BeatMapLoader\BeatMapLoader.cpp" />
@@ -129,6 +130,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Source\Application\BeatMapEditor\BeatMapEditor.h" />
+    <ClInclude Include="Source\Application\BeatMapEditor\BPMCounter\TapBPMCounter.h" />
     <ClInclude Include="Source\Application\BeatMapEditor\EditorCoordinate.h" />
     <ClInclude Include="Source\Application\BeatMapEditor\LiveMapping\LiveMapping.h" />
     <ClInclude Include="Source\Application\BeatMapLoader\BeatMapData.h" />

--- a/Application/RhythmProject.vcxproj.filters
+++ b/Application/RhythmProject.vcxproj.filters
@@ -70,6 +70,9 @@
     <Filter Include="Application\FeedBack\JudgeEffect">
       <UniqueIdentifier>{65add205-d443-47ac-99fc-3ea6b04894b7}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Application\BeatMapEditor\BPMCounter">
+      <UniqueIdentifier>{8d1b859e-d15f-4c03-8e79-72e0bc68b5ae}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />
@@ -155,6 +158,9 @@
       <Filter>Application\FeedBack</Filter>
     </ClCompile>
     <ClCompile Include="Source\Application\FeedBack\JudgeEffect\JudgeEffect.cpp" />
+    <ClCompile Include="Source\Application\BeatMapEditor\BPMCounter\TapBPMCounter.cpp">
+      <Filter>Application\BeatMapEditor\BPMCounter</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Source\Essential\SampleFramework.h">
@@ -255,6 +261,9 @@
     </ClInclude>
     <ClInclude Include="Source\Application\FeedBack\JudgeEffect\JudgeEffect.h">
       <Filter>Application\FeedBack\JudgeEffect</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\Application\BeatMapEditor\BPMCounter\TapBPMCounter.h">
+      <Filter>Application\BeatMapEditor\BPMCounter</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Application/Source/Application/BeatMapEditor/BPMCounter/TapBPMCounter.cpp
+++ b/Application/Source/Application/BeatMapEditor/BPMCounter/TapBPMCounter.cpp
@@ -1,0 +1,71 @@
+#include "TapBPMCounter.h"
+
+#include <Debug/ImGuiManager.h>
+
+void TapBPMCounter::Initialize()
+{
+    input_ = Input::GetInstance(); // 入力管理クラスのインスタンスを取得
+
+    stopwatch_.Reset();
+
+    tapTimes_.clear(); // タップ時間のベクターを初期化
+
+    totalTime_ = 0.0f;
+}
+
+void TapBPMCounter::Update()
+{
+    stopwatch_.Update();
+    if (input_->IsKeyTriggered(DIK_SPACE)) // スペースキーが押されたら
+    {
+        if (tapTimes_.empty())
+            stopwatch_.Start();
+
+
+        float currentTime = stopwatch_.GetElapsedTime<float>(); // 現在の時間を取得
+        totalTime_ += currentTime;
+        tapTimes_.push_back(currentTime); // タップ時間を記録
+        stopwatch_.Reset(); // ストップウォッチをリセット
+    }
+
+#ifdef _DEBUG
+
+    ImGui::Begin("Tap BPM Counter");
+    {
+        ImGui::Text("BPM : %.1f", GetBPM());
+        for (size_t i = 0; i < tapTimes_.size(); ++i)
+        {
+            ImGui::Text("Tap %zu: %6.2f ms", i + 1, tapTimes_[i] * 1000); // タップ時間を表示
+        }
+    }
+    ImGui::End();
+
+#endif // _DEBUG
+
+
+}
+
+void TapBPMCounter::Reset()
+{
+    stopwatch_.Reset(); // ストップウォッチをリセット
+    tapTimes_.clear(); // タップ時間のベクターをクリア
+    totalTime_ = 0.0f;
+}
+
+float TapBPMCounter::GetBPM() const
+{
+    if (tapTimes_.size() < 2)
+        return 0.0f; // タップが2回未満の場合はBPMを計算できない
+
+    int32_t tapCount = static_cast<int32_t>(tapTimes_.size());
+
+    float averageTime = totalTime_ / (tapCount - 1); // タップ間の平均時間を計算
+
+    if (averageTime <= 0.0f)
+        return 0.0f; // 平均時間が0以下の場合はBPMを計算できない
+
+    float bpm = 60.0f / averageTime; // BPMを計算
+
+    return bpm; // 計算したBPMを返す
+
+}

--- a/Application/Source/Application/BeatMapEditor/BPMCounter/TapBPMCounter.h
+++ b/Application/Source/Application/BeatMapEditor/BPMCounter/TapBPMCounter.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <System/Input/Input.h>
+#include <System/Time/Stopwatch.h>
+#include <System/Time/Time_MT.h>
+
+#include <vector>
+
+class TapBPMCounter
+{
+public:
+    TapBPMCounter() = default;
+    ~TapBPMCounter() = default;
+
+    void Initialize();
+
+    void Update();
+
+    void Reset();
+
+    float GetBPM() const;
+
+private:
+
+    Input* input_ = nullptr; // 入力管理クラスへのポインタ
+
+    Stopwatch stopwatch_; // タップの時間を計測するストップウォッチ
+
+    std::vector<float> tapTimes_; // タップした時間を記録するベクター
+    float totalTime_ = 0.0f; // タップの合計時間
+
+};

--- a/Application/Source/Application/BeatMapEditor/BeatMapEditor.h
+++ b/Application/Source/Application/BeatMapEditor/BeatMapEditor.h
@@ -12,6 +12,7 @@
 #include <Application/BeatsManager/BeatManager.h>
 
 #include <Application/BeatMapEditor/LiveMapping/LiveMapping.h>
+#include <Application/BeatMapEditor/BPMCounter/TapBPMCounter.h>
 
 #include <string>
 #include <cstdint>
@@ -285,16 +286,20 @@ private:
         PlaceLongNote,
         Delete,
         LiveMapping,
+        BPMSetting,
 
         Count // モードの数
     };
 
     EditorMode currentEditorMode_ = EditorMode::Select; // 現在のエディターモード
+    EditorMode preCurrentEditorMode_ = EditorMode::Select; // 現在のエディターモード
     bool isCreatingLongNote_ = false; // ロングノートを作成中かどうかのフラグ
     float longNoteStartTime_ = 0.0f; // ロングノートの開始時間
     int32_t longNoteStartLane_ = 0; // ロングノートの開始レーン
 
     LiveMapping liveMapping_;
+    TapBPMCounter tapBPMCounter_; // タップBPMカウンター
+    std::shared_ptr<VoiceInstance> voiceInstanceForBPMSet_; // 音楽の音声インスタンス
 
     // 配置プレビュー
     std::unique_ptr<UISprite> previewNoteSprite_; // ノート配置プレビュー用のスプライト

--- a/Application/Source/Application/Scene/GameScene.cpp
+++ b/Application/Source/Application/Scene/GameScene.cpp
@@ -64,7 +64,6 @@ void GameScene::Initialize(SceneData* _sceneData)
 
     beatManager_ = std::make_unique<BeatManager>();
     beatManager_->Initialize(100);
-    //beatManager_->SetEnableSound(false);
 
     feedbackEffect_ = std::make_unique<FeedbackEffect>();
     feedbackEffect_->Initialize();
@@ -76,7 +75,9 @@ void GameScene::Initialize(SceneData* _sceneData)
 
 
 #ifdef _DEBUG
+    beatManager_->SetEnableSound(true); // デバッグ時は音を有効にする
 #else
+    beatManager_->SetEnableSound(false); // デバッグ時以外は音を無効にする
 #endif // _DEBUG
     isBeatMapLoaded_ = false;
 
@@ -84,7 +85,6 @@ void GameScene::Initialize(SceneData* _sceneData)
 
 void GameScene::Update()
 {
-
     // ロードが完了してなかったら更新しない
     if (!IsComplateLoadBeatMap())
         return;
@@ -104,6 +104,17 @@ void GameScene::Update()
     ImGui();
 
 #pragma region Application
+
+    if (input_->IsKeyTriggered(DIK_R))
+    {
+        voiceInstance_->Stop();
+        voiceInstance_.reset();
+        voiceInstance_ = soundInstance_->Play(0.5f); // ボリュームとオフセットを設定して再生
+        gameCore_->Restart(voiceInstance_); // ゲームコアに音声インスタンスを設定
+        gameInputManager_->SetMusicVoiceInstance(voiceInstance_);
+        beatManager_->Reset();
+    }
+
 
     gameInputManager_->Update(); // 入力更新
     beatManager_->Update();

--- a/Application/imgui.ini
+++ b/Application/imgui.ini
@@ -9,31 +9,31 @@ Size=400,400
 Collapsed=0
 
 [Window][Engine]
-Pos=938,358
+Pos=939,358
 Size=346,267
 Collapsed=0
 DockId=0x00000006,2
 
 [Window][Debug]
-Pos=1001,14
+Pos=939,14
 Size=136,320
 Collapsed=0
 DockId=0x00000002,0
 
 [Window][DebugWindow]
-Pos=1139,14
+Pos=1077,14
 Size=135,320
 Collapsed=0
 DockId=0x00000003,0
 
 [Window][Input]
-Pos=938,358
+Pos=939,358
 Size=346,267
 Collapsed=0
 DockId=0x00000006,1
 
 [Window][SceneManager]
-Pos=938,358
+Pos=939,358
 Size=346,267
 Collapsed=0
 DockId=0x00000006,0
@@ -44,7 +44,7 @@ Size=449,97
 Collapsed=1
 
 [Window][Light Settings]
-Pos=938,358
+Pos=939,358
 Size=346,267
 Collapsed=0
 DockId=0x00000006,3
@@ -76,7 +76,7 @@ Size=376,304
 Collapsed=0
 
 [Window][BeatMap Editor]
-Pos=462,8
+Pos=312,4
 Size=664,713
 Collapsed=0
 
@@ -90,14 +90,19 @@ Pos=14,18
 Size=550,680
 Collapsed=1
 
+[Window][Tap BPM Counter]
+Pos=46,53
+Size=500,312
+Collapsed=0
+
 [Docking][Data]
-DockNode      ID=0x00000001 Pos=1001,14 Size=273,320 Split=X
+DockNode      ID=0x00000001 Pos=939,14 Size=273,320 Split=X
   DockNode    ID=0x00000002 Parent=0x00000001 SizeRef=319,648 Selected=0x1E7E18E3
   DockNode    ID=0x00000003 Parent=0x00000001 SizeRef=317,648 Selected=0x4B6712B0
-DockNode      ID=0x00000006 Pos=938,358 Size=346,267 Selected=0xDA40672E
+DockNode      ID=0x00000006 Pos=939,358 Size=346,267 Selected=0x1FDCDEE6
 DockSpace     ID=0x08BD597D Window=0x1BBC0F80 Pos=0,0 Size=32,32 Split=X
   DockNode    ID=0x00000007 Parent=0x08BD597D SizeRef=268,720 Selected=0xFBFB596A
   DockNode    ID=0x00000008 Parent=0x08BD597D SizeRef=1010,720 Split=Y
-    DockNode  ID=0x00000004 Parent=0x00000008 SizeRef=1280,586 CentralNode=1
+    DockNode  ID=0x00000004 Parent=0x00000008 SizeRef=1280,586 CentralNode=1 Selected=0x49BBF516
     DockNode  ID=0x00000005 Parent=0x00000008 SizeRef=1280,132 Selected=0x42899545
 


### PR DESCRIPTION
RhythmProjectにBPMカウンター機能を実装しました。`TapBPMCounter`クラスを新たに追加し、タップ時間を記録してBPMを計算する機能を提供します。`BeatMapEditor`にBPM設定モードを追加し、UIの調整も行いました。デバッグ時の音の設定も改善されました。