### PR TITLE
判定時に判定テキストを描画，アニメーションは未実装

### DIFF
--- a/Application/RhythmProject.vcxproj
+++ b/Application/RhythmProject.vcxproj
@@ -107,6 +107,7 @@
     <ClCompile Include="Source\Application\FeedBack\FeedbackEffect.cpp" />
     <ClCompile Include="Source\Application\FeedBack\JudgeEffect\JudgeEffect.cpp" />
     <ClCompile Include="Source\Application\FeedBack\JudgeSound\JudgeSound.cpp" />
+    <ClCompile Include="Source\Application\FeedBack\JudgeText\JudgeText.cpp" />
     <ClCompile Include="Source\Application\Input\GameInputManager.cpp" />
     <ClCompile Include="Source\Application\Lane\Lane.cpp" />
     <ClCompile Include="Source\Application\Note\Judge\JudgeLine.cpp" />
@@ -144,6 +145,7 @@
     <ClInclude Include="Source\Application\FeedBack\FeedbackEffect.h" />
     <ClInclude Include="Source\Application\FeedBack\JudgeEffect\JudgeEffect.h" />
     <ClInclude Include="Source\Application\FeedBack\JudgeSound\JudgeSound.h" />
+    <ClInclude Include="Source\Application\FeedBack\JudgeText\JudgeText.h" />
     <ClInclude Include="Source\Application\Input\GameInputManager.h" />
     <ClInclude Include="Source\Application\Input\InputData.h" />
     <ClInclude Include="Source\Application\Lane\Lane.h" />

--- a/Application/RhythmProject.vcxproj.filters
+++ b/Application/RhythmProject.vcxproj.filters
@@ -73,6 +73,9 @@
     <Filter Include="Application\BeatMapEditor\BPMCounter">
       <UniqueIdentifier>{8d1b859e-d15f-4c03-8e79-72e0bc68b5ae}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Application\FeedBack\JudgeText">
+      <UniqueIdentifier>{36b0ddf2-e0a1-4bb5-8294-02092c09ea62}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />
@@ -160,6 +163,9 @@
     <ClCompile Include="Source\Application\FeedBack\JudgeEffect\JudgeEffect.cpp" />
     <ClCompile Include="Source\Application\BeatMapEditor\BPMCounter\TapBPMCounter.cpp">
       <Filter>Application\BeatMapEditor\BPMCounter</Filter>
+    </ClCompile>
+    <ClCompile Include="Source\Application\FeedBack\JudgeText\JudgeText.cpp">
+      <Filter>Application\FeedBack\JudgeText</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -264,6 +270,9 @@
     </ClInclude>
     <ClInclude Include="Source\Application\BeatMapEditor\BPMCounter\TapBPMCounter.h">
       <Filter>Application\BeatMapEditor\BPMCounter</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\Application\FeedBack\JudgeText\JudgeText.h">
+      <Filter>Application\FeedBack\JudgeText</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Application/Source/Application/Core/GameCore.cpp
+++ b/Application/Source/Application/Core/GameCore.cpp
@@ -134,8 +134,8 @@ void GameCore::JudgeNotes(const std::vector<InputDate>& _inputData)
         judgeResult_->AddJudge(result);
         note->Judge();
 
-        if(onJudgeCallback_)
-            onJudgeCallback_(laneIndex); // 判定時のコールバックを呼び出す
+        if (onJudgeCallback_)
+            onJudgeCallback_(laneIndex, result); // 判定時のコールバックを呼び出す
     }
 }
 

--- a/Application/Source/Application/Core/GameCore.h
+++ b/Application/Source/Application/Core/GameCore.h
@@ -73,7 +73,7 @@ public:
     /// 判定時のコールバック関数を設定する
     /// </summary>
     /// <param name="_callback">コールバック関数</param>
-    void SetJudgeCallback(const std::function<void(int32_t)>& _callback) { onJudgeCallback_ = _callback; }
+    void SetJudgeCallback(const std::function<void(int32_t,JudgeType)>& _callback) { onJudgeCallback_ = _callback; }
 
 private:
 
@@ -108,7 +108,7 @@ private:
     // コールバック関連
 
     // 判定時のコールバック関数
-    std::function<void(int32_t)> onJudgeCallback_;
+    std::function<void(int32_t, JudgeType)> onJudgeCallback_;
 
 
     float noteDeletePosition_ = -10.0f; // ノーツを削除する位置

--- a/Application/Source/Application/FeedBack/FeedbackEffect.cpp
+++ b/Application/Source/Application/FeedBack/FeedbackEffect.cpp
@@ -1,29 +1,76 @@
 #include "FeedbackEffect.h"
 
-void FeedbackEffect::Initialize()
+#include <Features/Camera/Camera/Camera.h>
+
+void FeedbackEffect::Initialize(Camera* _camera)
 {
+    if (_camera)
+        camera_ = _camera;
+
     judgeSound_ = std::make_unique<JudgeSound>();
     judgeSound_->Initialize();
 
     judgeEffect_ = std::make_unique<JudgeEffect>();
     judgeEffect_->Initialize();
+
+    for (int32_t i = 0; i < judgeTextPool_.size(); ++i)
+    {
+        judgeTextPool_[i] = std::make_unique<JudgeText>();
+        usedJudgeTexts_.set(i, false); // 初期化時は全て未使用
+    }
 }
 
 void FeedbackEffect::Update()
 {
     if (judgeSound_)
         judgeSound_->CleanupStoppedVoices(); // 停止した音声をクリーンアップ
+
+    for (int32_t i = 0; i < judgeTextPool_.size(); ++i)
+    {
+        if (usedJudgeTexts_[i]) // 使用中のテキストのみ更新
+        {
+            judgeTextPool_[i]->Update(0.016f); // TODO 仮のデルタタイムを使用
+            if (judgeTextPool_[i]->IsFinished()) // 終了したテキストは未使用に戻す
+            {
+                usedJudgeTexts_.set(i, false);
+            }
+        }
+    }
 }
 
 void FeedbackEffect::Draw()
 {
+    for (int32_t i = 0; i < judgeTextPool_.size(); ++i)
+    {
+        if (usedJudgeTexts_[i]) // 使用中のテキストのみ描画
+        {
+            judgeTextPool_[i]->Draw();
+        }
+    }
 }
 
-void FeedbackEffect::PlayJudgeEffect(int32_t _laneIndex)
+void FeedbackEffect::PlayJudgeEffect(int32_t _laneIndex, JudgeType _judgeType)
 {
+
     if (judgeSound_)
         judgeSound_->Play();
 
     if (judgeEffect_)
         judgeEffect_->Play(_laneIndex);
+
+    AllocateJudgeText(_judgeType, _laneIndex); // 判定テキストを割り当てる
+}
+
+void FeedbackEffect::AllocateJudgeText(JudgeType _judgeType, int32_t _laneIndex)
+{
+    for (int32_t i = 0; i < judgeTextPool_.size(); ++i)
+    {
+        if (!usedJudgeTexts_[i]) // 未使用のテキストを探す
+        {
+            usedJudgeTexts_.set(i); // 使用中に設定
+            judgeTextPool_[i]->Initialize(_judgeType, _laneIndex, camera_);
+            return; // 割り当て完了
+        }
+    }
+
 }

--- a/Application/Source/Application/FeedBack/FeedbackEffect.h
+++ b/Application/Source/Application/FeedBack/FeedbackEffect.h
@@ -1,9 +1,16 @@
 #pragma once
 
+
 #include <Application/FeedBack/JudgeSound/JudgeSound.h>
 #include <Application/FeedBack/JudgeEffect/JudgeEffect.h>
+#include <Application/FeedBack/JudgeText/JudgeText.h>
 
 #include <memory>
+#include <vector>
+#include <list>
+#include <bitset>
+
+class Camera;
 
 // フィードバックエフェクト
 // 音やパーティクルなど統括する 予定
@@ -13,14 +20,24 @@ public:
     FeedbackEffect() = default;
     ~FeedbackEffect() = default;
 
-    void Initialize();
+    void Initialize(Camera* _camera);
     void Update();
     void Draw();
 
     /// <summary>
     /// ジャッジエフェクトを再生する(コールバック用)
     /// </summary>
-    void PlayJudgeEffect(int32_t _laneIndex);
+    void PlayJudgeEffect(int32_t _laneIndex, JudgeType _judgeType);
+
+private:
+
+    /// <summary>
+    /// 判定テキストを割り当てる
+    /// </summary>
+    /// <param name="_judgeType">判定タイプ</param>
+    /// <param name="_position">座標</param>
+    void AllocateJudgeText(JudgeType _judgeType, int32_t _laneIndex);
+
 
 private:
 
@@ -30,6 +47,15 @@ private:
     /// パーティクル
     std::unique_ptr<JudgeEffect> judgeEffect_;
 
+    /// 判定テキスト
+    static const int32_t kMaxJudgeTexts_ = 10; // 最大の判定テキスト数
+    std::array<std::unique_ptr<JudgeText>, kMaxJudgeTexts_> judgeTextPool_;
+    std::bitset<kMaxJudgeTexts_> usedJudgeTexts_; // 使用中のテキストを管理するビットセット
+
     /// UI
+
+
+    // 座標変換用カメラ
+    Camera* camera_ = nullptr; // カメラへのポインタ
 
 };

--- a/Application/Source/Application/FeedBack/JudgeText/JudgeText.cpp
+++ b/Application/Source/Application/FeedBack/JudgeText/JudgeText.cpp
@@ -1,0 +1,107 @@
+#include "JudgeText.h"
+
+#include <Features/TextRenderer/TextRenderer.h>
+#include <Math/Mylib.h>
+
+#include <Application/Lane/Lane.h>
+
+float JudgeText::displayYOffset_ = -100.0f; // Y軸のオフセットを初期化
+
+JudgeText::JudgeText():
+    judgeType_(JudgeType::None),
+    position_(0.0f, 0.0f),
+    timer_(0.0f),
+    displayDuration_(1.0f), // 初期表示時間を設定
+    textRenderer_(TextRenderer::GetInstance()) // テキストレンダラーのインスタンスを取得
+{
+}
+
+void JudgeText::Initialize(JudgeType _judgeType, int32_t _laneIndex, const Camera* _camera)
+{
+    position_ = _camera->WotldToScreen(Lane::GetLaneEndPosition(_laneIndex));
+    position_.y += displayYOffset_; // Y軸のオフセットを適用
+
+    judgeType_ = _judgeType; // 判定タイプを設定
+
+    timer_ = 0.0f; // タイマー初期化
+    displayDuration_ = 1.0f; // 表示時間の初期化
+
+    judgeText_ = GetJudgeText(judgeType_); // 判定テキストの初期化
+    GetJudgeTextColor(judgeType_, topColor_, bottomColor_); // 判定テキストの色を取得
+
+    if(!textRenderer_)
+        textRenderer_ = TextRenderer::GetInstance(); // テキストレンダラーのインスタンスを取得
+
+}
+
+void JudgeText::Update(float _deltaTime)
+{
+    timer_ += _deltaTime;
+
+    // 表示時間を超えたら終了
+    if (timer_ >= displayDuration_)
+    {
+        judgeType_ = JudgeType::None; // 判定をリセット
+        judgeText_.clear(); // テキストをクリア
+    }
+}
+
+void JudgeText::Draw()
+{
+    textRenderer_->DrawText(judgeText_, position_, topColor_, bottomColor_);
+}
+
+std::wstring JudgeText::GetJudgeText(JudgeType _judgeType)
+{
+	switch (_judgeType)
+	{
+	case JudgeType::Perfect:
+        return L"PERFECT";
+		break;
+
+	case JudgeType::Good:
+        return L"GOOD";
+		break;
+
+	case JudgeType::Miss:
+        return L"MISS";
+		break;
+
+	case JudgeType::None:
+	case JudgeType::MAX:
+	default:
+        // 判定なしの場合はerrorを返す
+        return L"error";
+		break;
+	}
+
+    return L"error";
+}
+
+void JudgeText::GetJudgeTextColor(JudgeType _judgeType, Vector4& _topColor, Vector4& _bottomColor)
+{
+    switch (_judgeType)
+    {
+    case JudgeType::Perfect:
+        // ピンクから水色
+        _topColor = ColorCodeToVector4(0xff66b8ff); // ピンク色
+        _bottomColor = Vector4(0.0f, 1.0f, 1.0f, 1.0f); // 水色
+        break;
+    case JudgeType::Good:
+        // 緑から薄い緑
+        _topColor = Vector4(0.0f, 1.0f, 0.0f, 1.0f); // 緑色
+        _bottomColor = Vector4(0.5f, 1.0f, 0.5f, 1.0f); // 薄い緑色
+        break;
+    case JudgeType::Miss:
+        // グレー
+        _topColor = Vector4(0.5f, 0.5f, 0.5f, 1.0f); // グレー
+        _bottomColor = Vector4(0.5f, 0.5f, 0.5f, 1.0f); // グレー
+        break;
+    case JudgeType::None:
+    case JudgeType::MAX:
+    default:
+        _topColor = Vector4(1.0f, 1.0f, 1.0f, 1.0f); // 白色
+        _bottomColor = Vector4(1.0f, 1.0f, 1.0f, 1.0f);
+        break;
+    }
+}

--- a/Application/Source/Application/FeedBack/JudgeText/JudgeText.h
+++ b/Application/Source/Application/FeedBack/JudgeText/JudgeText.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <Math/Vector/Vector3.h>
+#include <Math/Vector/Vector4.h>
+
+#include <Application/Note/Judge/JudgeType.h>
+
+#include <string>
+
+class TextRenderer;
+class Camera; // 前方宣言
+
+class JudgeText
+{
+public:
+    // コンストラクタ
+    JudgeText();
+    // デストラクタ
+    ~JudgeText() = default;
+
+    /// <summary>
+    /// 初期化処理
+    /// </summary>
+    /// <param name="_judgeType">判定タイプ</param>
+    /// <param name="_laneIndex">レーンインデックス</param>
+    void Initialize(JudgeType _judgeType, int32_t _laneIndex, const Camera* _camera);
+
+    /// <summary>
+    /// 更新処理
+    /// </summary>
+    /// <param name="_deltaTime">デルタタイム</param>
+    void Update(float _deltaTime);
+
+    /// <summary>
+    /// 描画処理
+    /// </summary>
+    void Draw();
+
+
+    /// <summary>
+    /// 描画時間が経過したかどうかを判定
+    /// </summary>
+    /// <returns>true: 経過した, false: 経過していない</returns>
+    bool IsFinished() const { return timer_ >= displayDuration_; }
+
+private:
+    /// <summary>
+    /// 判定タイプに応じたテキストを取得
+    /// </summary>
+    /// <param name="_judgeType">判定タイプ</param>
+    /// <returns>判定テキスト</returns>
+    static std::wstring GetJudgeText(JudgeType _judgeType);
+
+    /// <summary>
+    /// 判定タイプに応じたテキストの色を取得
+    /// </summary>
+    /// <param name="_judgeType">判定タイプ</param>
+    /// <param name="_topColor">上頂点の色</param>
+    /// <param name="_bottomColor">下頂点の色</param>
+    static void GetJudgeTextColor(JudgeType _judgeType, Vector4& _topColor, Vector4& _bottomColor);
+
+
+    static float displayYOffset_; // Y軸のオフセット
+private:
+
+    TextRenderer* textRenderer_ = nullptr; // テキストレンダラー
+
+    JudgeType judgeType_; // 判定タイプ
+
+    Vector4 topColor_ = Vector4(1.0f, 1.0f, 1.0f, 1.0f); // 上頂点の色
+    Vector4 bottomColor_ = Vector4(0.5f, 0.5f, 0.5f, 1.0f); // 下頂点の色
+
+    std::wstring judgeText_; // 判定テキスト
+
+    Vector2 position_;
+    float timer_ = 0.0f; // 表示時間のタイマー
+    float displayDuration_ = 1.0f; // 表示時間
+
+};

--- a/Application/Source/Application/Scene/GameScene.cpp
+++ b/Application/Source/Application/Scene/GameScene.cpp
@@ -66,9 +66,9 @@ void GameScene::Initialize(SceneData* _sceneData)
     beatManager_->Initialize(100);
 
     feedbackEffect_ = std::make_unique<FeedbackEffect>();
-    feedbackEffect_->Initialize();
+    feedbackEffect_->Initialize(&SceneCamera_);
 
-    gameCore_->SetJudgeCallback([&](int32_t _laneIndex) {feedbackEffect_->PlayJudgeEffect(_laneIndex); });
+    gameCore_->SetJudgeCallback([&](int32_t _laneIndex, JudgeType _judgeType) {feedbackEffect_->PlayJudgeEffect(_laneIndex, _judgeType); });
 
 
     SceneManager::GetInstance()->SetTransition(std::make_unique<SceneTrans>());
@@ -119,7 +119,7 @@ void GameScene::Update()
     gameInputManager_->Update(); // 入力更新
     beatManager_->Update();
     gameCore_->Update(static_cast<float>(GameTime::GetInstance()->GetDeltaTime()), gameInputManager_->GetInputData());
-
+    feedbackEffect_->Update();
 
 
 #pragma endregion // Application
@@ -154,6 +154,8 @@ void GameScene::Draw()
 
     Sprite::PreDraw();
     //noteKeyController_->Draw();
+
+    feedbackEffect_->Draw();
 
     particleSystem_->DrawParticles();
 }


### PR DESCRIPTION
フィードバックエフェクトに判定テキスト機能追加

`JudgeText` に関連するソースファイルとヘッダーファイルを追加し、フィードバックエフェクトに判定テキストを表示する機能を実装しました。 `GameCore` のコールバック関数を変更し、判定結果を引数として渡すようにしました。
`FeedbackEffect` にカメラを引数に取る `Initialize` メソッドを追加し、判定テキストを管理するためのプールとビットセットを導入しました。 `JudgeText` クラスを実装し、判定タイプに応じたテキストと色を取得するメソッドを追加しました。 `GameScene` では、フィードバックエフェクトの初期化時にカメラを渡すように変更し、コールバックの設定を更新しました。