### PR TITLE
ImGuiの呼び出し位置をまとめた

### DIFF
--- a/Application/Source/Application/Core/GameCore.cpp
+++ b/Application/Source/Application/Core/GameCore.cpp
@@ -64,10 +64,6 @@ void GameCore::Update(float  _deltaTime, const std::vector<InputDate>& _inputDat
             elapsedTime = voiceInstance->GetElapsedTime();
         }
     }
-#ifdef _DEBUG
-    ImGui::DragFloat("speed", &noteSpeed_, 0.01f);
-#endif // _DEBUG
-    noteJudge_->SetSpeed(noteSpeed_);
     for (auto& lane : lanes_)
     {
         lane->Update(elapsedTime, noteSpeed_);

--- a/Application/Source/Application/Core/GameCore.h
+++ b/Application/Source/Application/Core/GameCore.h
@@ -75,6 +75,12 @@ public:
     /// <param name="_callback">コールバック関数</param>
     void SetJudgeCallback(const std::function<void(int32_t,JudgeType)>& _callback) { onJudgeCallback_ = _callback; }
 
+
+    /// <summary>
+    /// ノーツの移動速度を設定する
+    /// </summary>
+    /// <param name="_speed">ノーツの移動速度</param>
+    void SetNoteSpeed(float _speed) { noteSpeed_ = _speed; noteJudge_->SetSpeed(noteSpeed_); }
 private:
 
     void JudgeNotes(const std::vector<InputDate>& _inputData);

--- a/Application/imgui.ini
+++ b/Application/imgui.ini
@@ -1,10 +1,10 @@
 [Window][WindowOverViewport_11111111]
-Pos=0,0
+Pos=0,19
 Size=32,32
 Collapsed=0
 
 [Window][Debug##Default]
-Pos=60,60
+Pos=405,155
 Size=400,400
 Collapsed=0
 
@@ -15,13 +15,13 @@ Collapsed=0
 DockId=0x00000006,2
 
 [Window][Debug]
-Pos=939,14
+Pos=983,48
 Size=136,320
 Collapsed=0
 DockId=0x00000002,0
 
 [Window][DebugWindow]
-Pos=1077,14
+Pos=1121,48
 Size=135,320
 Collapsed=0
 DockId=0x00000003,0
@@ -101,7 +101,7 @@ Size=161,77
 Collapsed=0
 
 [Window][JudgeText]
-Pos=0,17
+Pos=0,36
 Size=32,19
 Collapsed=0
 DockId=0x0000000A,0
@@ -111,16 +111,34 @@ Pos=25,19
 Size=343,186
 Collapsed=0
 
+[Window][Dear ImGui ID Stack Tool]
+Pos=60,60
+Size=415,134
+Collapsed=0
+
+[Window][GameScene]
+Pos=729,336
+Size=257,272
+Collapsed=0
+DockId=0x0000000B,0
+
+[Window][Camera]
+Pos=729,336
+Size=257,272
+Collapsed=0
+DockId=0x0000000B,1
+
 [Docking][Data]
-DockNode        ID=0x00000001 Pos=939,14 Size=273,320 Split=X
+DockNode        ID=0x00000001 Pos=983,48 Size=273,320 Split=X
   DockNode      ID=0x00000002 Parent=0x00000001 SizeRef=319,648 Selected=0x1E7E18E3
   DockNode      ID=0x00000003 Parent=0x00000001 SizeRef=317,648 Selected=0x4B6712B0
 DockNode        ID=0x00000006 Pos=961,364 Size=346,265 Selected=0x1FDCDEE6
-DockSpace       ID=0x08BD597D Window=0x1BBC0F80 Pos=0,0 Size=32,32 Split=Y
-  DockNode      ID=0x00000009 Parent=0x08BD597D SizeRef=1280,571 Split=X
+DockNode        ID=0x0000000B Pos=729,336 Size=257,272 Selected=0x76349C10
+DockSpace       ID=0x08BD597D Window=0x1BBC0F80 Pos=0,19 Size=32,32 Split=Y
+  DockNode      ID=0x00000009 Parent=0x08BD597D SizeRef=1280,533 Split=X
     DockNode    ID=0x00000007 Parent=0x00000009 SizeRef=268,720 Selected=0xFBFB596A
     DockNode    ID=0x00000008 Parent=0x00000009 SizeRef=1010,720 Split=Y
       DockNode  ID=0x00000004 Parent=0x00000008 SizeRef=1280,586 CentralNode=1 Selected=0x49BBF516
       DockNode  ID=0x00000005 Parent=0x00000008 SizeRef=1280,132 Selected=0x42899545
-  DockNode      ID=0x0000000A Parent=0x08BD597D SizeRef=1280,147 Selected=0xB31907B2
+  DockNode      ID=0x0000000A Parent=0x08BD597D SizeRef=1280,166 Selected=0xB31907B2
 


### PR DESCRIPTION
`GameCore.cpp` に音楽の経過時間取得機能を追加し、デバッグ用のスピード調整機能を削除。`GameCore.h` にノーツの移動速度を設定する `SetNoteSpeed` メソッドを追加。

`GameScene.cpp` では、デバッグ用のImGuiウィンドウを追加し、音楽の再生・停止、BPM設定、音量調整機能を改善。音楽の経過時間や長さを表示する機能も追加。

`imgui.ini` でウィンドウの位置やサイズを変更し、新しいデバッグウィンドウとゲームシーンウィンドウを追加。

`Engine` のサブプロジェクトのコミットIDを更新。