### PR TITLE
手動設定のフィルターが原因で音声ファイルのロードができなかったのを修正

### DIFF
--- a/Application/Source/Application/BeatMapEditor/BeatMapEditor.cpp
+++ b/Application/Source/Application/BeatMapEditor/BeatMapEditor.cpp
@@ -497,7 +497,8 @@ void BeatMapEditor::DrawUI()
         ImGui::SeparatorText("Music Control");
         if (ImGui::Button("Load Music"))
         {
-            std::string musicFilePath = FileDialog::OpenFile("Audio Files (*.wav;)\0*.wav;\0");
+            std::string musicFilePath = FileDialog::OpenFile(FileFilterBuilder::GetFilterString(FileFilterBuilder::FilterType::AudioFiles));
+
             if (!musicFilePath.empty())
             {
                 // 音楽ファイルのパスを設定

--- a/Application/Source/Application/BeatMapEditor/EditorCoordinate.cpp
+++ b/Application/Source/Application/BeatMapEditor/EditorCoordinate.cpp
@@ -139,8 +139,8 @@ void EditorCoordinate::GetVisibleTimeRange(float& _startTime, float& _endTime) c
         cachedVisibleStartTime_ = ScreenYToTime(screenSize_.y - bottomMargin_);
         cachedVisibleEndTime_ = ScreenYToTime(topMargin_); // 上端は0.0f
 
-        Debug::Log(std::format("Visible Time Range: Start = {:.2f}, End = {:.2f}\n", cachedVisibleStartTime_, cachedVisibleEndTime_));
-        Debug::Log(std::format("startPosY = {:.2f}, endPosY = {:.2f}\n", TimeToScreenY(cachedVisibleStartTime_), TimeToScreenY(cachedVisibleEndTime_)));
+        //Debug::Log(std::format("Visible Time Range: Start = {:.2f}, End = {:.2f}\n", cachedVisibleStartTime_, cachedVisibleEndTime_));
+        //Debug::Log(std::format("startPosY = {:.2f}, endPosY = {:.2f}\n", TimeToScreenY(cachedVisibleStartTime_), TimeToScreenY(cachedVisibleEndTime_)));
 
         visibleRangeDirty_ = false; // 可視範囲が更新されたのでフラグをリセット
     }

--- a/Application/Source/Application/Lane/Lane.cpp
+++ b/Application/Source/Application/Lane/Lane.cpp
@@ -46,7 +46,6 @@ void Lane::Update(float _elapseTime, float _speed)
 
 void Lane::Draw(const Camera* _camera) const
 {
-    //  TODO レーン描画
     if (laneModel_)
     {
         laneModel_->Draw(_camera, { 0.5f,0.5f,0.5f,0.7f });
@@ -122,7 +121,6 @@ void Lane::CreateNotes(const std::list<NoteData>& _noteDataList, int32_t _laneIn
         if (noteData.laneIndex == _laneIndex) // 念のためチェック
         {
             // ノーツを生成して追加
-            // TODO : ノーツの種類に応じて生成するクラスを変更する
             if(noteData.noteType =="normal")
             {
                 auto note = std::make_shared<NomalNote>();

--- a/Application/Source/Application/Note/Note.cpp
+++ b/Application/Source/Application/Note/Note.cpp
@@ -38,8 +38,6 @@ void Note::Draw(const Camera* _camera)
 void Note::Judge()
 {
     isJudged_ = true; // 判定済みにする
-    //TODO: 音鳴らす
-    // event発行？soundInstance持たせる？
 }
 
 NomalNote::NomalNote() :    Note()

--- a/Application/imgui.ini
+++ b/Application/imgui.ini
@@ -1,6 +1,6 @@
 [Window][WindowOverViewport_11111111]
 Pos=0,19
-Size=32,32
+Size=1280,701
 Collapsed=0
 
 [Window][Debug##Default]
@@ -33,8 +33,8 @@ Collapsed=0
 DockId=0x00000004,1
 
 [Window][SceneManager]
-Pos=343,65
-Size=243,218
+Pos=299,29
+Size=243,246
 Collapsed=0
 
 [Window][Timeline]
@@ -90,8 +90,8 @@ Size=550,680
 Collapsed=0
 
 [Window][Tap BPM Counter]
-Pos=46,53
-Size=500,312
+Pos=47,51
+Size=500,659
 Collapsed=0
 
 [Window][FeedbackEffect Debug]
@@ -137,7 +137,7 @@ DockNode        ID=0x00000001 Pos=983,48 Size=273,320 Split=X
   DockNode      ID=0x00000002 Parent=0x00000001 SizeRef=319,648 Selected=0x1E7E18E3
   DockNode      ID=0x00000003 Parent=0x00000001 SizeRef=317,648 Selected=0x4B6712B0
 DockNode        ID=0x0000000B Pos=729,336 Size=257,272 Selected=0xAA49D574
-DockSpace       ID=0x08BD597D Window=0x1BBC0F80 Pos=0,19 Size=32,32 Split=Y
+DockSpace       ID=0x08BD597D Window=0x1BBC0F80 Pos=0,19 Size=1280,701 Split=Y
   DockNode      ID=0x00000009 Parent=0x08BD597D SizeRef=1280,533 Split=X
     DockNode    ID=0x00000007 Parent=0x00000009 SizeRef=268,720 Selected=0xFBFB596A
     DockNode    ID=0x00000008 Parent=0x00000009 SizeRef=1010,720 Split=Y


### PR DESCRIPTION
それとTODOの整理

UI改善とデバッグログの整理

BeatMapEditor.cppのDrawUI関数で音楽ファイルのフィルタを改善し、空でない場合のみビートマップデータに音楽ファイルパスを設定する処理を追加しました。 EditorCoordinate.cppではデバッグログをコメントアウトし、可視範囲更新時のフラグリセットを明示化しました。 Lane.cppのUpdate関数とCreateNotes関数からTODOコメントを削除し、処理を明確にしました。 Note.cppのJudge関数でもTODOコメントを削除し、判定済みフラグの設定を明確にしました。 imgui.iniではウィンドウの位置とサイズ設定を変更し、特定のウィンドウサイズを拡大しました。