### PR TITLE
ノート移動時に巻き込みが発生していたのを修正

### DIFF
--- a/Application/Source/Application/BeatMapEditor/BeatMapEditor.h
+++ b/Application/Source/Application/BeatMapEditor/BeatMapEditor.h
@@ -143,7 +143,12 @@ private:
     /// 選択中のノートを移動
     /// </summary>
     /// <param name="_deltaTime">新しい時間</param>
-    void MoveSelectedNote(float _newTime);
+    void MoveSelectedNoteTemporary(float _newTime);
+
+    /// <summary>
+    /// 選択中のノートを移動確定
+    /// </summary>
+    void ConfirmMoveSelectedMove();
 
     /// <summary>
     /// ライブマッピングを適用
@@ -258,6 +263,17 @@ private:
     /// </summary>
     void DrawSelectionArea();
 
+
+
+
+    ///=======================================
+    /// UI分割
+
+    void DrawLeftPanel();
+    void DrawRightPanel();
+
+
+
 private:
     enum class EditorMode
     {
@@ -271,6 +287,20 @@ private:
         Count // モードの数
     };
 
+    struct NoteColor
+    {
+        Vector4 defaultColor;
+        Vector4 hoverColor;
+        Vector4 selectedColor;
+    };
+
+    struct MoveState
+    {
+        bool isMoving = false; // 移動中フラグ
+        std::vector<float> originalTimes; // 元の時間
+        std::vector<size_t> movingIndices; // 移動対象のノートインデックス
+
+    };
 private:
     // ========================================
     // システム依存関係
@@ -320,6 +350,7 @@ private:
     bool isMovingSelectedNote_ = false;
     int32_t lastSelectedNoteIndex_ = -1;
     bool isRangeSelected_ = false;
+    MoveState moveState_;
 
     // ========================================
     // ロングノート編集状態
@@ -348,11 +379,6 @@ private:
     // ========================================
     // ノート色設定
     // ========================================
-    struct NoteColor {
-        Vector4 defaultColor;
-        Vector4 hoverColor;
-        Vector4 selectedColor;
-    };
     NoteColor normalNoteColor_;
     NoteColor longNoteColor_;
 

--- a/Application/Source/Application/Command/MoveNoteCommand.cpp
+++ b/Application/Source/Application/Command/MoveNoteCommand.cpp
@@ -32,7 +32,6 @@ void MoveNoteCommand::Execute()
         float newTime = originalTimes_[i] + deltaTime_;
         beatMapEditor_->SetNoteTime(index, newTime);
     }
-    beatMapEditor_->SortNotesByTime(); // ノートを時間順にソート
 }
 
 void MoveNoteCommand::Undo()
@@ -54,5 +53,4 @@ void MoveNoteCommand::Undo()
             beatMapEditor_->SetNoteTime(static_cast<size_t>(noteIndex), originalTimes_[i]);
         }
     }
-    beatMapEditor_->SortNotesByTime(); // ノートを時間順にソート
 }

--- a/Application/imgui.ini
+++ b/Application/imgui.ini
@@ -1,6 +1,6 @@
 [Window][WindowOverViewport_11111111]
 Pos=0,19
-Size=32,32
+Size=1280,701
 Collapsed=0
 
 [Window][Debug##Default]
@@ -9,19 +9,19 @@ Size=400,400
 Collapsed=0
 
 [Window][Engine]
-Pos=961,364
-Size=346,265
+Pos=270,19
+Size=1010,701
 Collapsed=0
-DockId=0x00000004,2
+DockId=0x00000004,0
 
 [Window][Debug]
-Pos=983,48
+Pos=495,411
 Size=136,320
 Collapsed=0
 DockId=0x00000002,0
 
 [Window][DebugWindow]
-Pos=1121,48
+Pos=633,411
 Size=135,320
 Collapsed=0
 DockId=0x00000003,0
@@ -33,7 +33,7 @@ Collapsed=0
 DockId=0x00000004,1
 
 [Window][SceneManager]
-Pos=403,69
+Pos=347,50
 Size=243,246
 Collapsed=0
 
@@ -60,7 +60,8 @@ Size=120,141
 Collapsed=0
 
 [Window][Emitter]
-Size=268,720
+Pos=0,19
+Size=268,701
 Collapsed=0
 DockId=0x00000007,0
 
@@ -128,20 +129,35 @@ Collapsed=0
 DockId=0x0000000B,1
 
 [Window][LightGroup]
-Pos=60,61
-Size=207,192
+Pos=642,173
+Size=207,215
+Collapsed=0
+
+[Window][NoteInfo]
+Pos=16,35
+Size=161,278
+Collapsed=0
+
+[Window][Editor Controls]
+Pos=0,18
+Size=300,702
+Collapsed=0
+
+[Window][Information]
+Pos=980,18
+Size=300,702
 Collapsed=0
 
 [Docking][Data]
-DockNode        ID=0x00000001 Pos=983,48 Size=273,320 Split=X
+DockNode        ID=0x00000001 Pos=495,411 Size=273,320 Split=X
   DockNode      ID=0x00000002 Parent=0x00000001 SizeRef=319,648 Selected=0x1E7E18E3
   DockNode      ID=0x00000003 Parent=0x00000001 SizeRef=317,648 Selected=0x4B6712B0
 DockNode        ID=0x0000000B Pos=729,336 Size=257,272 Selected=0xAA49D574
-DockSpace       ID=0x08BD597D Window=0x1BBC0F80 Pos=0,19 Size=32,32 Split=Y
+DockSpace       ID=0x08BD597D Window=0x1BBC0F80 Pos=0,19 Size=1280,701 Split=Y
   DockNode      ID=0x00000009 Parent=0x08BD597D SizeRef=1280,533 Split=X
     DockNode    ID=0x00000007 Parent=0x00000009 SizeRef=268,720 Selected=0xFBFB596A
     DockNode    ID=0x00000008 Parent=0x00000009 SizeRef=1010,720 Split=Y
-      DockNode  ID=0x00000004 Parent=0x00000008 SizeRef=1280,586 CentralNode=1 Selected=0x1FDCDEE6
+      DockNode  ID=0x00000004 Parent=0x00000008 SizeRef=1280,586 CentralNode=1 Selected=0xAC437A35
       DockNode  ID=0x00000005 Parent=0x00000008 SizeRef=1280,132 Selected=0x42899545
   DockNode      ID=0x0000000A Parent=0x08BD597D SizeRef=1280,166 Selected=0xB31907B2
 


### PR DESCRIPTION
デバッグ機能の追加とノート移動処理の改善

BeatMapEditor.cppにおいて、`ImGuiDebugManager.h`を追加し、エディタのUIにデバッグ情報を表示する機能を実装しました。初期画面サイズを修正し、左パネルと右パネルを描画する新しいメソッドを追加しました。また、選択されたノートの情報を表示するUIを追加し、ノートの移動処理を改善しました。`HandleInput`メソッドに`moveState_`構造体を導入し、選択エリアのサイズに基づいてノートインデックスをクリアするロジックを変更しました。さらに、`imgui.ini`ファイルのウィンドウ設定を調整し、`MoveNoteCommand`クラスのソート処理を削除しました。