### PR TITLE
UIの整理とレイアウトの変更とその他修正

### DIFF
--- a/Application/Source/Application/BeatMapEditor/BeatMapEditor.h
+++ b/Application/Source/Application/BeatMapEditor/BeatMapEditor.h
@@ -55,7 +55,16 @@ public:
     /// ノートを削除
     /// </summary>
     /// <param name="_noteIndex">削除するノートのインデックス</param>
+    /// <returns>削除されたノートデータ</returns>
     NoteData DeleteNote(size_t _noteIndex);
+
+    /// <summary>
+    /// ノートを削除
+    /// </summary>
+    /// <param name="_laneIndex"> レーンインデックス</param>
+    /// <param name="_targetTime"> ターゲット時間</param>
+    /// <returns> 削除されたノートデータ</returns>
+    NoteData DeleteNote(uint32_t _laneIndex, float _targetTime);
 
 
     /// <summary>
@@ -405,8 +414,9 @@ private:
 
     // 選択・判定用
     std::unique_ptr<UISprite> areaSelectionSprite_;
-    std::unique_ptr<UISprite> dummy_editArea_;
+    std::unique_ptr<UISprite> dummy_editLaneArea_;
     std::unique_ptr<UISprite> dummy_window_;
+    std::unique_ptr<UISprite> dummy_editArea_;
 
     // ========================================
     // 特殊機能

--- a/Application/Source/Application/BeatMapEditor/EditorCoordinate.cpp
+++ b/Application/Source/Application/BeatMapEditor/EditorCoordinate.cpp
@@ -3,6 +3,7 @@
 
 EditorCoordinate::EditorCoordinate() :
     screenSize_(1280.0f, 720.0f),
+    areaCenter_(640.0f, 360.0f), // 初期エリアセンター
     laneCount_(4),
     editAreaX_(100.0f),
     editAreaWidth_(400.0f),
@@ -20,11 +21,12 @@ EditorCoordinate::EditorCoordinate() :
 {
 }
 
-void EditorCoordinate::Initialize(const Vector2& _screenSize, uint32_t _laneCount)
+void EditorCoordinate::Initialize(const Vector2& _screenSize, const Vector2& _areaCenter, uint32_t _laneCount)
 {
     screenSize_ = _screenSize;
     laneCount_ = _laneCount;
 
+    areaCenter_ = _areaCenter;
 
     UpdateLayout();
     InvalidateVisibleRange();
@@ -282,8 +284,8 @@ void EditorCoordinate::UpdateLayout()
     // 編集エリアのレイアウト計算
     // 画面の中央部分をエディット領域として使用
     float sideMargin = screenSize_.x * 0.1f;  // 左右10%をマージン
-    editAreaX_ = sideMargin;
-    editAreaWidth_ = screenSize_.x - (sideMargin * 2.0f);
+    editAreaX_ = areaCenter_.x - screenSize_.x / 2.0f + sideMargin;
+    editAreaWidth_ = screenSize_.x - (sideMargin * 2.0f) ;
 
     // レーン幅計算（4レーン等分）
     laneMargin_ = editAreaWidth_ * 0.02f;  // レーン間の余白（全体の2%）

--- a/Application/Source/Application/BeatMapEditor/EditorCoordinate.h
+++ b/Application/Source/Application/BeatMapEditor/EditorCoordinate.h
@@ -18,7 +18,7 @@ public:
     /// </summary>
     /// <param name="_screenSize">画面サイズ</param>
     /// <param name="_laneCount">レーン数(デフォルト4)</param>
-    void Initialize(const Vector2& _screenSize, uint32_t _laneCount = 4);
+    void Initialize(const Vector2& _screenSize, const Vector2& _areaCenter = { 640,360 }, uint32_t _laneCount = 4);
 
     /// <summary>
     /// 画面サイズを設定
@@ -33,7 +33,7 @@ public:
     /// <param name="_height">画面高さ</param>
     void SetScreenSize(float _width, float _height);
 
-    
+
     float GetLaneLeftX(uint32_t _laneIndex) const;
     float GetLaneRightX(uint32_t _laneIndex) const;
 
@@ -161,6 +161,8 @@ private:
 
     Vector2 screenSize_; // 画面サイズ
     uint32_t laneCount_; // レーン数
+
+    Vector2 areaCenter_;
 
     // レイアウト設定
     float editAreaX_;        // 編集エリアの左端X座標

--- a/Application/Source/Application/Command/DeleteNoteCommand.cpp
+++ b/Application/Source/Application/Command/DeleteNoteCommand.cpp
@@ -2,6 +2,12 @@
 
 DeleteNoteCommand::DeleteNoteCommand(BeatMapEditor* _beatMapEditor, uint32_t _noteIndex):
     beatMapEditor_(_beatMapEditor),
+    noteIndex_({ _noteIndex })
+{
+}
+
+DeleteNoteCommand::DeleteNoteCommand(BeatMapEditor* _beatMapEditor, std::vector<uint32_t> _noteIndex) :
+    beatMapEditor_(_beatMapEditor),
     noteIndex_(_noteIndex)
 {
 }
@@ -12,10 +18,20 @@ void DeleteNoteCommand::Execute()
     {
         return;
     }
+
+    deletedNoteData_.clear();
+
+    std::vector<NoteData> deletedNotes;
     // ノートを削除
-    deletedNoteData_ = beatMapEditor_->DeleteNote(noteIndex_);
-
-
+    for(uint32_t index : noteIndex_)
+    {
+        deletedNotes.push_back(beatMapEditor_->GetNoteAt(index));
+    }
+    for (NoteData& note : deletedNotes)
+    {
+        // 削除したノートのデータを保存
+        deletedNoteData_.push_back(beatMapEditor_->DeleteNote(note.laneIndex, note.targetTime));
+    }
 }
 
 void DeleteNoteCommand::Undo()
@@ -25,5 +41,9 @@ void DeleteNoteCommand::Undo()
         return;
     }
 
-    beatMapEditor_->InsertNote(deletedNoteData_); // 削除したノートを挿入して元に戻す
+    for (const auto& note : deletedNoteData_)
+    {
+        // 削除したノートを元に戻す
+        beatMapEditor_->InsertNote(note);
+    }
 }

--- a/Application/Source/Application/Command/DeleteNoteCommand.h
+++ b/Application/Source/Application/Command/DeleteNoteCommand.h
@@ -9,6 +9,7 @@ class DeleteNoteCommand : public ICommand
 public:
 
     DeleteNoteCommand(BeatMapEditor* _beatMapEditor, uint32_t _noteIndex);
+    DeleteNoteCommand(BeatMapEditor* _beatMapEditor, std::vector<uint32_t> _noteIndex);
 
     void Execute() override;
     void Undo() override;
@@ -17,6 +18,6 @@ public:
 private:
 
     BeatMapEditor* beatMapEditor_ = nullptr; // BeatMapEditorのポインタ
-    uint32_t noteIndex_ = 0; // 削除するノートのインデックス
-    NoteData deletedNoteData_; // 削除したノートのデータを保存
+    std::vector<uint32_t> noteIndex_; // 削除するノートのインデックス
+    std::vector<NoteData> deletedNoteData_; // 削除したノートのデータを保存
 };

--- a/Application/Source/Essential/SampleFramework.cpp
+++ b/Application/Source/Essential/SampleFramework.cpp
@@ -31,7 +31,7 @@ void SampleFramework::Initialize(const std::wstring& _winTitle)
     Time_MT::GetInstance()->Initialize();
 
     // 最初のシーンで初期化
-    sceneManager_->Initialize("GameScene");
+    sceneManager_->Initialize("TitleScene");
 }
 
 void SampleFramework::Update()

--- a/Application/imgui.ini
+++ b/Application/imgui.ini
@@ -12,28 +12,26 @@ Collapsed=0
 Pos=270,19
 Size=1010,701
 Collapsed=0
-DockId=0x00000004,0
-
-[Window][Debug]
-Pos=495,411
-Size=136,320
-Collapsed=0
 DockId=0x00000002,0
 
-[Window][DebugWindow]
-Pos=633,411
-Size=135,320
+[Window][Debug]
+Pos=996,19
+Size=284,701
 Collapsed=0
 DockId=0x00000003,0
 
+[Window][DebugWindow]
+Pos=702,697
+Size=273,320
+Collapsed=1
+
 [Window][Input]
-Pos=961,364
-Size=346,265
+Pos=955,230
+Size=425,198
 Collapsed=0
-DockId=0x00000004,1
 
 [Window][SceneManager]
-Pos=347,50
+Pos=323,65
 Size=243,246
 Collapsed=0
 
@@ -46,7 +44,7 @@ Collapsed=1
 Pos=939,358
 Size=346,267
 Collapsed=0
-DockId=0x00000004,3
+DockId=0x00000002,3
 
 [Window][TimeLine]
 Pos=270,588
@@ -117,19 +115,19 @@ Size=415,134
 Collapsed=0
 
 [Window][GameScene]
-Pos=729,336
+Pos=722,334
 Size=257,272
 Collapsed=0
 DockId=0x0000000B,0
 
 [Window][Camera]
-Pos=729,336
+Pos=722,334
 Size=257,272
 Collapsed=0
 DockId=0x0000000B,1
 
 [Window][LightGroup]
-Pos=642,173
+Pos=713,88
 Size=207,215
 Collapsed=0
 
@@ -148,16 +146,25 @@ Pos=980,18
 Size=300,702
 Collapsed=0
 
+[Window][CollisionManager]
+Pos=60,60
+Size=177,122
+Collapsed=0
+
+[Window][Time Info]
+Pos=728,3
+Size=170,105
+Collapsed=0
+
 [Docking][Data]
-DockNode        ID=0x00000001 Pos=495,411 Size=273,320 Split=X
-  DockNode      ID=0x00000002 Parent=0x00000001 SizeRef=319,648 Selected=0x1E7E18E3
-  DockNode      ID=0x00000003 Parent=0x00000001 SizeRef=317,648 Selected=0x4B6712B0
-DockNode        ID=0x0000000B Pos=729,336 Size=257,272 Selected=0xAA49D574
-DockSpace       ID=0x08BD597D Window=0x1BBC0F80 Pos=0,19 Size=1280,701 Split=Y
-  DockNode      ID=0x00000009 Parent=0x08BD597D SizeRef=1280,533 Split=X
-    DockNode    ID=0x00000007 Parent=0x00000009 SizeRef=268,720 Selected=0xFBFB596A
-    DockNode    ID=0x00000008 Parent=0x00000009 SizeRef=1010,720 Split=Y
-      DockNode  ID=0x00000004 Parent=0x00000008 SizeRef=1280,586 CentralNode=1 Selected=0xAC437A35
-      DockNode  ID=0x00000005 Parent=0x00000008 SizeRef=1280,132 Selected=0x42899545
-  DockNode      ID=0x0000000A Parent=0x08BD597D SizeRef=1280,166 Selected=0xB31907B2
+DockNode          ID=0x0000000B Pos=722,334 Size=257,272 Selected=0x76349C10
+DockSpace         ID=0x08BD597D Window=0x1BBC0F80 Pos=0,19 Size=1280,701 Split=Y
+  DockNode        ID=0x00000009 Parent=0x08BD597D SizeRef=1280,533 Split=X
+    DockNode      ID=0x00000007 Parent=0x00000009 SizeRef=268,720 Selected=0xFBFB596A
+    DockNode      ID=0x00000008 Parent=0x00000009 SizeRef=1010,720 Split=Y
+      DockNode    ID=0x00000004 Parent=0x00000008 SizeRef=1280,586 Split=X Selected=0xAC437A35
+        DockNode  ID=0x00000002 Parent=0x00000004 SizeRef=994,701 CentralNode=1 Selected=0x9ECF0FAD
+        DockNode  ID=0x00000003 Parent=0x00000004 SizeRef=284,701 Selected=0x1E7E18E3
+      DockNode    ID=0x00000005 Parent=0x00000008 SizeRef=1280,132 Selected=0x42899545
+  DockNode        ID=0x0000000A Parent=0x08BD597D SizeRef=1280,166 Selected=0xB31907B2
 


### PR DESCRIPTION
エディタ機能の改善とUIの整理

BeatMapEditor.cppのInitialize関数でレーンエリアのサイズ設定を追加し、ダミースプライトの初期化を変更しました。DrawUI関数にデバッグモードの条件付きコンパイルを追加し、UI要素を整理しました。DeleteNote関数をオーバーロードし、レーンインデックスとターゲット時間でノートを削除できるようにしました。HandleInput関数にBキーでビートの切り替え機能と選択ノート削除機能を追加しました。EditorCoordinateクラスの初期化関数を変更し、エリアの中心を指定できるようにしました。DeleteNoteCommandクラスに複数ノート削除用のコンストラクタを追加し、削除データ管理を強化しました。