### PR TITLE
gridにoffsetTimeを適用した，伴ってsnapなどの関数を修正

### DIFF
--- a/Application/Resources/Data/Game/BeatMap/demo1.json
+++ b/Application/Resources/Data/Game/BeatMap/demo1.json
@@ -8,187 +8,187 @@
             "holdDuration": 0.0,
             "laneIndex": 0,
             "noteType": "normal",
-            "targetTime": 0.625
+            "targetTime": 0.6366666555404663
         },
         {
             "holdDuration": 0.0,
             "laneIndex": 3,
             "noteType": "normal",
-            "targetTime": 0.625
+            "targetTime": 0.6366666555404663
         },
         {
             "holdDuration": 0.0,
             "laneIndex": 2,
             "noteType": "normal",
-            "targetTime": 2.2916665077209473
+            "targetTime": 2.303333282470703
         },
         {
             "holdDuration": 0.0,
             "laneIndex": 1,
             "noteType": "normal",
-            "targetTime": 2.2916665077209473
+            "targetTime": 2.303333282470703
         },
         {
             "holdDuration": 0.0,
             "laneIndex": 2,
             "noteType": "normal",
-            "targetTime": 3.9583332538604736
+            "targetTime": 3.9700000286102295
         },
         {
             "holdDuration": 0.0,
             "laneIndex": 1,
             "noteType": "normal",
-            "targetTime": 3.9583332538604736
+            "targetTime": 3.9700000286102295
         },
         {
             "holdDuration": 0.0,
             "laneIndex": 2,
             "noteType": "normal",
-            "targetTime": 5.625
+            "targetTime": 5.636666297912598
         },
         {
             "holdDuration": 0.0,
             "laneIndex": 0,
             "noteType": "normal",
-            "targetTime": 5.625
+            "targetTime": 5.636666297912598
         },
         {
             "holdDuration": 0.7291666269302368,
             "laneIndex": 3,
             "noteType": "hold",
-            "targetTime": 7.291666507720947
+            "targetTime": 7.303332805633545
         },
         {
             "holdDuration": 0.8436059951782227,
             "laneIndex": 0,
             "noteType": "hold",
-            "targetTime": 8.854166030883789
+            "targetTime": 8.865833282470703
         },
         {
             "holdDuration": 0.0,
             "laneIndex": 2,
             "noteType": "normal",
-            "targetTime": 10.625
+            "targetTime": 10.636666297912598
         },
         {
             "holdDuration": 0.0,
             "laneIndex": 1,
             "noteType": "normal",
-            "targetTime": 10.625
+            "targetTime": 10.636666297912598
         },
         {
             "holdDuration": 0.0,
             "laneIndex": 2,
             "noteType": "normal",
-            "targetTime": 11.458333015441895
+            "targetTime": 11.470000267028809
         },
         {
             "holdDuration": 0.0,
             "laneIndex": 1,
             "noteType": "normal",
-            "targetTime": 11.458333015441895
+            "targetTime": 11.470000267028809
         },
         {
             "holdDuration": 0.0,
             "laneIndex": 2,
             "noteType": "normal",
-            "targetTime": 12.291666030883789
+            "targetTime": 12.303333282470703
         },
         {
             "holdDuration": 0.0,
             "laneIndex": 1,
             "noteType": "normal",
-            "targetTime": 12.291666030883789
+            "targetTime": 12.303333282470703
         },
         {
             "holdDuration": 0.0,
             "laneIndex": 3,
             "noteType": "normal",
-            "targetTime": 13.125
+            "targetTime": 13.136666297912598
         },
         {
             "holdDuration": 0.0,
             "laneIndex": 0,
             "noteType": "normal",
-            "targetTime": 13.125
+            "targetTime": 13.136666297912598
         },
         {
             "holdDuration": 0.0,
             "laneIndex": 2,
             "noteType": "normal",
-            "targetTime": 13.958333015441895
+            "targetTime": 13.970000267028809
         },
         {
             "holdDuration": 0.0,
             "laneIndex": 1,
             "noteType": "normal",
-            "targetTime": 15.625
+            "targetTime": 15.636666297912598
         },
         {
             "holdDuration": 0.0,
             "laneIndex": 3,
             "noteType": "normal",
-            "targetTime": 17.29166603088379
+            "targetTime": 17.30333137512207
         },
         {
             "holdDuration": 0.0,
             "laneIndex": 2,
             "noteType": "normal",
-            "targetTime": 18.958332061767578
+            "targetTime": 18.969999313354492
         },
         {
             "holdDuration": 0.0,
             "laneIndex": 1,
             "noteType": "normal",
-            "targetTime": 19.375
+            "targetTime": 19.38666534423828
         },
         {
             "holdDuration": 0.7908134460449219,
             "laneIndex": 2,
             "noteType": "hold",
-            "targetTime": 19.79166603088379
+            "targetTime": 19.80333137512207
         },
         {
             "holdDuration": 0.0,
             "laneIndex": 0,
             "noteType": "normal",
-            "targetTime": 22.29166603088379
+            "targetTime": 22.30333137512207
         },
         {
             "holdDuration": 0.0,
             "laneIndex": 2,
             "noteType": "normal",
-            "targetTime": 22.29166603088379
+            "targetTime": 22.30333137512207
         },
         {
             "holdDuration": 0.0,
             "laneIndex": 3,
             "noteType": "normal",
-            "targetTime": 23.958332061767578
+            "targetTime": 23.969999313354492
         },
         {
             "holdDuration": 0.0,
             "laneIndex": 1,
             "noteType": "normal",
-            "targetTime": 23.958332061767578
+            "targetTime": 23.969999313354492
         },
         {
             "holdDuration": 0.0,
             "laneIndex": 2,
             "noteType": "normal",
-            "targetTime": 25.208332061767578
+            "targetTime": 25.219999313354492
         },
         {
             "holdDuration": 0.0,
             "laneIndex": 1,
             "noteType": "normal",
-            "targetTime": 25.625
+            "targetTime": 25.63666534423828
         },
         {
             "holdDuration": 0.0,
             "laneIndex": 2,
             "noteType": "normal",
-            "targetTime": 26.04166603088379
+            "targetTime": 26.05333137512207
         }
     ],
     "offset": 0.2199999988079071,

--- a/Application/Source/Application/BeatMapEditor/BeatMapEditor.cpp
+++ b/Application/Source/Application/BeatMapEditor/BeatMapEditor.cpp
@@ -425,7 +425,10 @@ void BeatMapEditor::DrawLeftPanel()
 
         ImGui::SeparatorText("Offset");
         if (ImGui::DragFloat("Offset", &currentBeatMapData_.offset, 0.01f, -100.0f, 100.0f, " %.3f s")) // オフセットの入力フィールド
+        {
             beatManager_->SetOffset(currentBeatMapData_.offset); // オフセットを設定
+            editorCoordinate_.SetOffsetTime(currentBeatMapData_.offset); // エディターのオフセットを設定
+        }
 
         ImGui::Dummy(ImVec2(0.0f, spacing)); // スペーシングを追加
 
@@ -700,7 +703,7 @@ void BeatMapEditor::LoadBeatMap(const std::string& _beatMapPath)
     {
         return;
     }
-
+     
      auto future = beatMapLoader_->LoadBeatMap(_beatMapPath);
 
     // ロードが完了するまで待機
@@ -709,6 +712,11 @@ void BeatMapEditor::LoadBeatMap(const std::string& _beatMapPath)
         Reset(); // エディターの状態をリセット
         currentBeatMapData_ = beatMapLoader_->GetLoadedBeatMapData();
         currentFilePath_ = _beatMapPath; // 現在のファイルパスを更新
+
+        beatManager_->SetBPM(currentBeatMapData_.bpm); // BPMを設定
+        beatManager_->SetOffset(currentBeatMapData_.offset); // オフセットを設定
+
+        editorCoordinate_.SetOffsetTime(currentBeatMapData_.offset); // エディターのオフセットを設定
 
         std::string musicFilePath = currentBeatMapData_.audioFilePath;
         if (!musicFilePath.empty())

--- a/Application/Source/Application/BeatMapEditor/EditorCoordinate.h
+++ b/Application/Source/Application/BeatMapEditor/EditorCoordinate.h
@@ -111,7 +111,6 @@ public:
     /// <returns>グリッドラインのY座標リスト</returns>
     std::vector<std::pair<float, int32_t>> GetGridLinesY(float _bpm, int _division = 4) const;
 
-
     /// <summary>
     /// 時間をグリッドにスナップ
     /// </summary>
@@ -129,7 +128,7 @@ public:
     /// <returns>画面内にある場合true</returns>
     bool IsNoteVisible(float _noteTime) const;
 
-
+    void SetOffsetTime(float _offsetTime) { offsetTime_ = _offsetTime; InvalidateVisibleRange(); }
 
 
     // ========================================
@@ -145,6 +144,9 @@ public:
     float GetEditAreaWidth() const { return editAreaWidth_; }
     float GetLaneMargin() const { return laneMargin_; }
     float GetTimeZeroOffsetRatio() const { return timeZeroOffsetRatio_; }
+    float GetAreaCenterX() const { return areaCenter_.x; }
+    float GetAreaCenterY() const { return areaCenter_.y; }
+    float GetOffsetTime() const { return offsetTime_; }
 
     float GetTopMargin() const { return topMargin_; }
     float GetBottomMargin() const { return bottomMargin_; }
@@ -184,4 +186,5 @@ private:
     mutable bool visibleRangeDirty_;
 
     float timeZeroOffsetRatio_;
+    float offsetTime_ = 0.0f;
 };

--- a/Application/imgui.ini
+++ b/Application/imgui.ini
@@ -1,6 +1,6 @@
 [Window][WindowOverViewport_11111111]
 Pos=0,19
-Size=1280,701
+Size=32,32
 Collapsed=0
 
 [Window][Debug##Default]
@@ -15,8 +15,8 @@ Collapsed=0
 DockId=0x00000002,0
 
 [Window][Debug]
-Pos=996,19
-Size=284,701
+Pos=17,19
+Size=15,32
 Collapsed=0
 DockId=0x00000003,0
 
@@ -99,8 +99,8 @@ Size=161,77
 Collapsed=0
 
 [Window][JudgeText]
-Pos=0,554
-Size=1280,166
+Pos=0,36
+Size=32,19
 Collapsed=0
 DockId=0x0000000A,0
 
@@ -157,8 +157,8 @@ Size=170,105
 Collapsed=0
 
 [Docking][Data]
-DockNode          ID=0x0000000B Pos=722,334 Size=257,272 Selected=0x76349C10
-DockSpace         ID=0x08BD597D Window=0x1BBC0F80 Pos=0,19 Size=1280,701 Split=Y
+DockNode          ID=0x0000000B Pos=722,334 Size=257,272 Selected=0xAA49D574
+DockSpace         ID=0x08BD597D Window=0x1BBC0F80 Pos=0,19 Size=32,32 Split=Y
   DockNode        ID=0x00000009 Parent=0x08BD597D SizeRef=1280,533 Split=X
     DockNode      ID=0x00000007 Parent=0x00000009 SizeRef=268,720 Selected=0xFBFB596A
     DockNode      ID=0x00000008 Parent=0x00000009 SizeRef=1010,720 Split=Y


### PR DESCRIPTION
ノートのターゲット時間とオフセットの調整

demo1.jsonでノートのターゲット時間を微調整し、オフセットの値も変更しました。新たにoffset_Test.wavを追加し、BeatMapEditor.cppのDrawLeftPanel関数にオフセット設定機能を追加しました。LoadBeatMap関数ではBPMとオフセットの設定を行い、EditorCoordinate.cppのGetGridLinesY関数でオフセットを考慮したグリッドラインの計算を実装しました。SnapTimeToGrid関数もオフセットを考慮してスナップするように変更され、EditorCoordinate.hにオフセット時間を設定・取得するメソッドを追加しました。imgui.iniではウィンドウの位置とサイズの設定を調整しました。