### PR TITLE
簡易的にセレクトから譜面を選んでゲームシーンに行けるようにした

### DIFF
--- a/Application/RhythmProject.vcxproj
+++ b/Application/RhythmProject.vcxproj
@@ -166,6 +166,7 @@
     <ClInclude Include="Source\Application\Note\Judge\NoteJudge.h" />
     <ClInclude Include="Source\Application\Note\Note.h" />
     <ClInclude Include="Source\Application\Note\NoteType.h" />
+    <ClInclude Include="Source\Application\Scene\Data\SelectToGameData.h" />
     <ClInclude Include="Source\Application\Scene\GameScene.h" />
     <ClInclude Include="Source\Application\Scene\ResultScene.h" />
     <ClInclude Include="Source\Application\Scene\SelectScene.h" />

--- a/Application/RhythmProject.vcxproj.filters
+++ b/Application/RhythmProject.vcxproj.filters
@@ -82,6 +82,9 @@
     <Filter Include="Application\BeatMapEditor\Command\Core">
       <UniqueIdentifier>{7dc5343b-ca7f-453f-af53-f9fc2b9d8298}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Application\Scene\Data">
+      <UniqueIdentifier>{b70322d9-5112-44a6-ac87-505f780bc756}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />
@@ -312,6 +315,9 @@
     </ClInclude>
     <ClInclude Include="Source\Application\Command\ChangeHoldDurationCommand.h">
       <Filter>Application\BeatMapEditor\Command</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\Application\Scene\Data\SelectToGameData.h">
+      <Filter>Application\Scene\Data</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Application/Source/Application/BeatMapEditor/BeatMapEditor.h
+++ b/Application/Source/Application/BeatMapEditor/BeatMapEditor.h
@@ -383,7 +383,6 @@ private:
     // ========================================
     // 描画制御・インデックス管理
     // ========================================
-    float scrollOffset_ = 0.0f;
     uint32_t noteIndex_ = 0;
     uint32_t holdNoteIndex_ = 0;
     std::vector<uint32_t> drawNoteIndices_;

--- a/Application/Source/Application/Scene/Data/SelectToGameData.h
+++ b/Application/Source/Application/Scene/Data/SelectToGameData.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <Features/Scene/SceneData.h>
+
+struct SelectToGameData : SceneData
+{
+    std::string selectedBeatMapFilePath; // 選択された譜面ファイルのパス
+
+
+};

--- a/Application/Source/Application/Scene/GameScene.cpp
+++ b/Application/Source/Application/Scene/GameScene.cpp
@@ -9,11 +9,13 @@
 
 #include <System/Time/GameTime.h>
 
-#include <Application/Scene/Transition/SceneTrans.h>
 #include <Debug/Debug.h>
 #include <Debug/ImguITools.h>
 #include <Debug/ImGuiDebugManager.h>
 #include <Features/TextRenderer/TextRenderer.h>
+
+#include <Application/Scene/Transition/SceneTrans.h>
+#include <Application/Scene/Data/SelectToGameData.h>
 
 GameScene::~GameScene()
 {
@@ -53,8 +55,18 @@ void GameScene::Initialize(SceneData* _sceneData)
 
     ///---------------------------------
     /// Application
-    ///---------------------------------
     GenerateModels();
+
+    std::string beatMapFilePath = "Resources/Data/Game/BeatMap/demo1.json"; // デフォルトの譜面ファイルパス
+    if (_sceneData)
+    {
+        auto data = static_cast<SelectToGameData*>(_sceneData);
+        if (data)
+        {
+            beatMapFilePath = data->selectedBeatMapFilePath; // 選択された譜面ファイルのパスを取得
+        }
+    }
+
 
     gameCore_ = std::make_unique<GameCore>(); // レーン数はデフォで4
     gameCore_->Initialize(30.0f, 2.0f); // ノーツの移動速度とオフセット時間を設定
@@ -63,7 +75,7 @@ void GameScene::Initialize(SceneData* _sceneData)
     gameInputManager_->Initialize(input_);
 
     beatMapLoader_ = BeatMapLoader::GetInstance();
-    beatMapLoadFuture_ = beatMapLoader_->LoadBeatMap("Resources/Data/Game/BeatMap/demo1.json");
+    beatMapLoadFuture_ = beatMapLoader_->LoadBeatMap(beatMapFilePath);
 
     beatManager_ = std::make_unique<BeatManager>();
     beatManager_->Initialize(100);
@@ -234,8 +246,7 @@ bool GameScene::IsComplateLoadBeatMap()
         gameCore_->GenerateNotes(beatMapLoader_->GetLoadedBeatMapData());
 
         // bpmを設定
-        static float bpm = beatMapLoader_->GetLoadedBeatMapData().bpm;
-        beatManager_->SetBPM(bpm);
+        beatManager_->SetBPM(beatMapLoader_->GetLoadedBeatMapData().bpm);
         beatManager_->SetOffset(beatMapLoader_->GetLoadedBeatMapData().offset);
         std::string audioFilePath = beatMapLoader_->GetLoadedBeatMapData().audioFilePath;
         soundInstance_ = AudioSystem::GetInstance()->Load(audioFilePath);

--- a/Application/Source/Application/Scene/SelectScene.cpp
+++ b/Application/Source/Application/Scene/SelectScene.cpp
@@ -1,5 +1,10 @@
 #include "SelectScene.h"
 
+#include <Utility/FileDialog/FileDialog.h>
+#include <Utility/StringUtils/StringUitls.h>
+#include <Features/Scene/Manager/SceneManager.h>
+#include <Application/Scene/Data/SelectToGameData.h>
+
 void SelectScene::Initialize(SceneData* _sceneData)
 {
     SceneCamera_.Initialize();
@@ -21,8 +26,18 @@ void SelectScene::Initialize(SceneData* _sceneData)
     lightGroup_ = std::make_shared<LightGroup>();
     lightGroup_->Initialize();
 
+    textRenderer_ = TextRenderer::GetInstance();
+
 
     LightingSystem::GetInstance()->SetActiveGroup(lightGroup_);
+
+    selectButton_ = std::make_unique<UIButton>();
+    selectButton_->Initialize("SelectButton");
+    selectButton_->SetPos({ 640, 360 });
+    selectButton_->SetSize({ 200, 100 });
+    selectButton_->SetAnchor({ 0.5f,0.5f });
+    selectButton_->SetColor({ 0,0,0,1 });
+
 }
 
 void SelectScene::Update()
@@ -33,7 +48,7 @@ void SelectScene::Update()
     if (Input::GetInstance()->IsKeyTriggered(DIK_F1))
         enableDebugCamera_ = !enableDebugCamera_;
 
-    lightGroup_->ImGui();
+    //lightGroup_->ImGui();
 
 #endif // _DEBUG
 
@@ -51,13 +66,41 @@ void SelectScene::Update()
 
     particleSystem_->Update();
 
+    if (selectButton_->IsMousePointerInside())
+    {
+        if (input_->IsMouseTriggered(0))
+        {
+            std::string file = FileDialog::OpenFile(FileFilterBuilder::GetFilterString(FileFilterBuilder::FilterType::DataFiles));
+            if (!file.empty())
+            {
+                std::string substr = StringUtils::GetAfterLast(file, "Resources");
+                file = "Resources" + substr;
 
+                auto data = std::make_unique<SelectToGameData>();
+                data->selectedBeatMapFilePath = file;
+                SceneManager::ReserveScene("GameScene", std::move(data));
+            }
+        }
 
+    }
+
+    TextParam param;
+    param.SetColor({ 1,1,1,1 })
+        .SetPivot({ 0.5f, 0.5f })
+        .SetPosition({ 640, 200 })
+        .SetScale({ 1.0f, 1.0f });
+
+    textRenderer_->DrawText(L"せれくとしーん", param);
+
+    param.SetPosition({ 640, 360 });
+    textRenderer_->DrawText(L"譜面ファイル選択(仮)", param);
 }
 
 void SelectScene::Draw()
 {
 
+    Sprite::PreDraw();
+    selectButton_->Draw();
 }
 
 void SelectScene::DrawShadow() {}

--- a/Application/Source/Application/Scene/SelectScene.h
+++ b/Application/Source/Application/Scene/SelectScene.h
@@ -7,7 +7,9 @@
 #include <Features/LineDrawer/LineDrawer.h>
 #include <System/Time/Stopwatch.h>
 #include <Features/Effect/Manager/ParticleSystem.h>
+#include <Features/TextRenderer/TextRenderer.h>
 
+#include <Features/UI/UIButton.h>
 
 class SelectScene : public BaseScene
 {
@@ -33,6 +35,10 @@ private:
     Input* input_ = nullptr;
     ParticleSystem* particleSystem_ = nullptr;
 
+    TextRenderer* textRenderer_ = nullptr;
+
     std::shared_ptr<LightGroup> lightGroup_ = nullptr;
+
+    std::unique_ptr<UIButton> selectButton_ = nullptr;
 
 };

--- a/Application/imgui.ini
+++ b/Application/imgui.ini
@@ -1,6 +1,6 @@
 [Window][WindowOverViewport_11111111]
 Pos=0,19
-Size=32,32
+Size=1280,701
 Collapsed=0
 
 [Window][Debug##Default]
@@ -31,7 +31,7 @@ Size=425,198
 Collapsed=0
 
 [Window][SceneManager]
-Pos=283,100
+Pos=290,188
 Size=243,246
 Collapsed=0
 
@@ -53,7 +53,7 @@ Collapsed=0
 DockId=0x00000005,0
 
 [Window][JudgeResult]
-Pos=20,18
+Pos=18,30
 Size=120,141
 Collapsed=0
 
@@ -115,13 +115,13 @@ Size=415,134
 Collapsed=0
 
 [Window][GameScene]
-Pos=722,334
+Pos=711,255
 Size=257,272
 Collapsed=0
 DockId=0x0000000B,0
 
 [Window][Camera]
-Pos=722,334
+Pos=711,255
 Size=257,272
 Collapsed=0
 DockId=0x0000000B,1
@@ -157,28 +157,28 @@ Size=170,105
 Collapsed=0
 
 [Window][Timeline Setting]
-Pos=560,35
+Pos=491,51
 Size=380,385
 Collapsed=0
 
 [Window][Selected Items]
-Pos=771,104
-Size=137,146
+Pos=872,71
+Size=214,162
 Collapsed=0
 
 [Window][Tab Flags]
-Pos=432,54
+Pos=220,37
 Size=114,54
 Collapsed=0
 
 [Window][Select Item]
-Pos=301,40
-Size=119,54
+Pos=512,60
+Size=239,157
 Collapsed=0
 
 [Docking][Data]
-DockNode          ID=0x0000000B Pos=722,334 Size=257,272 Selected=0xAA49D574
-DockSpace         ID=0x08BD597D Window=0x1BBC0F80 Pos=0,19 Size=32,32 Split=Y
+DockNode          ID=0x0000000B Pos=711,255 Size=257,272 Selected=0x76349C10
+DockSpace         ID=0x08BD597D Window=0x1BBC0F80 Pos=0,19 Size=1280,701 Split=Y
   DockNode        ID=0x00000009 Parent=0x08BD597D SizeRef=1280,533 Split=X
     DockNode      ID=0x00000007 Parent=0x00000009 SizeRef=268,720 Selected=0xFBFB596A
     DockNode      ID=0x00000008 Parent=0x00000009 SizeRef=1010,720 Split=Y


### PR DESCRIPTION
新しいシーンデータとUI要素の追加

RhythmProject.vcxprojに`SelectToGameData.h`を追加し、プロジェクトに必要なヘッダーを整理しました。 `Application\Scene\Data`フィルターを追加し、関連するソースファイルを整理しました。

BeatMapEditor.cppの`Initialize`関数で、再生ヘッドの初期位置を`currentTime_`に基づくように変更しました。 `Update`関数で`UpdateTimeline`を呼び出し、エディターの状態更新時にタイムラインも更新されるようにしました。 `HandleInput`関数でスクロールオフセットの更新を`currentTime_`に基づくようにし、一貫性のある時間管理を実現しました。 `Reset`関数で`scrollOffset_`の初期化を削除し、`currentTime_`のみを初期化するようにしました。

新たに追加された`SelectToGameData.h`では、選択された譜面ファイルのパスを保持する構造体を定義しました。 GameScene.cppではデフォルトの譜面ファイルパスを`SelectToGameData`から取得するように変更し、シーンデータの初期化を改善しました。 SelectScene.cppにファイル選択ダイアログを追加し、ユーザーが譜面ファイルを選択できるようにしました。 SelectScene.hでは`TextRenderer`と`UIButton`のポインタを追加し、UI要素の管理を強化しました。 最後に、imgui.iniでウィンドウの位置やサイズを調整し、UIのレイアウトを改善しました。