### PR TITLE
コピペを実装，初期シーンをエディタに変更

### DIFF
--- a/Application/RhythmProject.vcxproj
+++ b/Application/RhythmProject.vcxproj
@@ -103,6 +103,7 @@
     <ClCompile Include="Source\Application\Command\CommandHistory.cpp" />
     <ClCompile Include="Source\Application\Command\DeleteNoteCommand.cpp" />
     <ClCompile Include="Source\Application\Command\MoveNoteCommand.cpp" />
+    <ClCompile Include="Source\Application\Command\PasteCommand.cpp" />
     <ClCompile Include="Source\Application\Command\PlaceNoteCommand.cpp" />
     <ClCompile Include="Source\Application\Core\GameCore.cpp" />
     <ClCompile Include="Source\Application\Effects\LaneEffect\LaneEffect.cpp" />
@@ -148,6 +149,7 @@
     <ClInclude Include="Source\Application\Command\DeleteNoteCommand.h" />
     <ClInclude Include="Source\Application\Command\ICommand.h" />
     <ClInclude Include="Source\Application\Command\MoveNoteCommand.h" />
+    <ClInclude Include="Source\Application\Command\PasteCommand.h" />
     <ClInclude Include="Source\Application\Command\PlaceNoteCommand.h" />
     <ClInclude Include="Source\Application\Core\GameCore.h" />
     <ClInclude Include="Source\Application\Effects\LaneEffect\LaneEffect.h" />

--- a/Application/RhythmProject.vcxproj.filters
+++ b/Application/RhythmProject.vcxproj.filters
@@ -194,6 +194,9 @@
     <ClCompile Include="Source\Application\Scene\EditorScene.cpp">
       <Filter>Application\Scene</Filter>
     </ClCompile>
+    <ClCompile Include="Source\Application\Command\PasteCommand.cpp">
+      <Filter>Application\BeatMapEditor\Command</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Source\Essential\SampleFramework.h">
@@ -324,6 +327,9 @@
     </ClInclude>
     <ClInclude Include="Source\Application\Scene\EditorScene.h">
       <Filter>Application\Scene</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\Application\Command\PasteCommand.h">
+      <Filter>Application\BeatMapEditor\Command</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Application/Source/Application/BeatMapEditor/BeatMapEditor.h
+++ b/Application/Source/Application/BeatMapEditor/BeatMapEditor.h
@@ -75,7 +75,7 @@ public:
     /// ノートを挿入
     /// </summary>
     /// <param name="_note"> 挿入するノートデータ</param>
-    void InsertNote(const NoteData& _note);
+    size_t InsertNote(const NoteData& _note);
 
     /// <summary>
     /// ノートを取得
@@ -174,6 +174,9 @@ private:
     /// </summary>
     void ApplyLiveMapping();
 
+    void CopySelectedNotes();
+
+    void PasteCopiedNotes();
     ///---------------------
     /// 内部処理関連
     ///
@@ -197,6 +200,8 @@ private:
     /// ノートが選択されているか確認
     /// </summary>
     bool IsNoteSelected(uint32_t _noteIndex) const;
+
+    size_t FindInsertNoteIndex(const NoteData& _note) const;
 
     /// <summary>
     /// ホールド終端から対応するノートインデックスを取得
@@ -323,6 +328,21 @@ private:
         std::vector<size_t> movingIndices; // 移動対象のノートインデックス
 
     };
+
+
+    struct ClipboardData
+    {
+        std::vector<NoteData> notes; // コピーしたノートデータ
+        float baseline = 0.0f; // コピーしたノートの基準時間
+
+        void Clear() {
+            notes.clear();
+            baseline = 0.0f;
+        };
+        bool IsEmpty() const {
+            return notes.empty();
+        }
+    };
 private:
     // ========================================
     // システム依存関係
@@ -374,6 +394,7 @@ private:
     int32_t lastSelectedNoteIndex_ = -1;
     bool isRangeSelected_ = false;
     MoveState moveState_;
+    ClipboardData clipboardData_;
 
     // ========================================
     // ロングノート編集状態

--- a/Application/Source/Application/Command/PasteCommand.cpp
+++ b/Application/Source/Application/Command/PasteCommand.cpp
@@ -1,0 +1,45 @@
+#include "PasteCommand.h"
+
+PasteCommand::PasteCommand(BeatMapEditor* _beatMapEditor, const std::vector<NoteData>& _notesToPaste, float _pasteOffset):
+    beatMapEditor_(_beatMapEditor),
+    notesToPaste_(_notesToPaste),
+    pasteOffset_(_pasteOffset)
+{
+}
+void PasteCommand::Execute()
+{
+    if (!beatMapEditor_)
+    {
+        return; // BeatMapEditorが無効な場合は何もしない
+    }
+    if (notesToPaste_.empty())
+    {
+        return; // コピーしたノートがない場合は何もしない
+    }
+    // ペーストオフセットを考慮してノートを配置
+    for (const auto& note : notesToPaste_)
+    {
+        NoteData newNote = note;
+        newNote.targetTime += pasteOffset_; // オフセットを適用
+        size_t noteIndex = beatMapEditor_->InsertNote(newNote); // ノートを挿入
+        if (noteIndex != SIZE_MAX) // ノートが正常に配置された場合
+        {
+            pastedNoteIndices_.push_back(noteIndex); // 配置したノートのインデックスを保存
+        }
+    }
+}
+
+void PasteCommand::Undo()
+{
+    if (!beatMapEditor_)
+    {
+        return; // BeatMapEditorが無効な場合は何もしない
+    }
+    // ペーストしたノートを削除
+    for (int32_t i = 0; i < pastedNoteIndices_.size(); ++i)
+    {
+        size_t index = pastedNoteIndices_[i];
+        beatMapEditor_->DeleteNote(index - i); // 消された分詰められているのでその分を考慮する
+    }
+    pastedNoteIndices_.clear(); // 削除後はインデックスをクリア
+}

--- a/Application/Source/Application/Command/PasteCommand.h
+++ b/Application/Source/Application/Command/PasteCommand.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <Application/Command/ICommand.h>
+
+#include <Application/BeatMapEditor/BeatMapEditor.h>
+
+class PasteCommand : public ICommand
+{
+public:
+    PasteCommand(BeatMapEditor* _beatMapEditor, const std::vector<NoteData>& _notesToPaste, float _pasteOffset = 0.0f);;
+    void Execute() override;
+    void Undo() override;
+private:
+
+    BeatMapEditor* beatMapEditor_ = nullptr; // BeatMapEditorのポインタ
+    std::vector<NoteData> notesToPaste_; // コピーしたノートデータ
+    std::vector<size_t> pastedNoteIndices_; // ペーストしたノートのインデックス
+    float pasteOffset_ = 0.0f; // ペーストオフセット時間
+};

--- a/Application/Source/Essential/SampleFramework.cpp
+++ b/Application/Source/Essential/SampleFramework.cpp
@@ -31,7 +31,7 @@ void SampleFramework::Initialize(const std::wstring& _winTitle)
     Time_MT::GetInstance()->Initialize();
 
     // 最初のシーンで初期化
-    sceneManager_->Initialize("TitleScene");
+    sceneManager_->Initialize("EditorScene");
 }
 
 void SampleFramework::Update()

--- a/Application/imgui.ini
+++ b/Application/imgui.ini
@@ -31,7 +31,7 @@ Size=425,198
 Collapsed=0
 
 [Window][SceneManager]
-Pos=86,54
+Pos=161,44
 Size=243,246
 Collapsed=0
 


### PR DESCRIPTION
ペースト機能を追加し、エディタシーンを設定

RhythmProjectに`PasteCommand`を追加し、ノートのコピー＆ペースト機能を実装しました。 `BeatMapEditor`にクリップボードデータ管理のための構造体を追加し、`InsertNote`関数の戻り値を変更しました。 初期化シーンを`EditorScene`に変更し、UIのレイアウトを調整しました。
エンジンのサブプロジェクトのコミットIDも更新しました。