### PR TITLE
sceneDataをstatic_castではなくdynamic_castで変換するようにし，型確認を行うように修正

### DIFF
--- a/Application/Source/Application/Core/GameCore.cpp
+++ b/Application/Source/Application/Core/GameCore.cpp
@@ -35,7 +35,7 @@ void GameCore::Initialize(float _noteSpeed, float _offset)
     judgeResult_->Initialize();
 
     noteJudge_->SetLaneTotalWidth(Lane::GetTotalWidth());
-
+    noteJudge_->SetSpeed(_noteSpeed);
 
     noteDeletePosition_ = -noteJudge_->GetMissJudgeThreshold() * noteSpeed_; // ノーツを削除する位置を設定
 }

--- a/Application/Source/Application/Scene/EditorScene.cpp
+++ b/Application/Source/Application/Scene/EditorScene.cpp
@@ -39,8 +39,9 @@ void EditorScene::Initialize(SceneData* _sceneData)
         if (_sceneData->beforeScene == "GameScene")
         {
             beatMapEditor_ = std::make_unique<BeatMapEditor>();
-            auto gameToEditorData = static_cast<SharedBeatMapData*>(_sceneData);
-            beatMapEditor_->Initialize(gameToEditorData->beatMapData); // ゲームから渡された譜面データを取得
+            auto gameToEditorData = dynamic_cast<SharedBeatMapData*>(_sceneData);
+            if (gameToEditorData)
+                beatMapEditor_->Initialize(gameToEditorData->beatMapData); // ゲームから渡された譜面データを取得
         }
     }
 

--- a/Application/Source/Application/Scene/GameScene.cpp
+++ b/Application/Source/Application/Scene/GameScene.cpp
@@ -58,21 +58,28 @@ void GameScene::Initialize(SceneData* _sceneData)
     GenerateModels();
 
     std::string beatMapFilePath = "Resources/Data/Game/BeatMap/demo1.json"; // デフォルトの譜面ファイルパス
+    gameMode_ = GameMode::Normal;
     if (_sceneData)
     {
         if (_sceneData->beforeScene == "SelectScene")
         {
-            auto selectToGameData = static_cast<SelectToGameData*>(_sceneData);
-            beatMapFilePath = selectToGameData->selectedBeatMapFilePath; // 選択された譜面ファイルパスを取得
-            gameMode_ = GameMode::Normal;
+            auto selectToGameData = dynamic_cast<SelectToGameData*>(_sceneData);
+            if (selectToGameData)
+            {
+                beatMapFilePath = selectToGameData->selectedBeatMapFilePath; // 選択された譜面ファイルパスを取得
+                gameMode_ = GameMode::Normal;
+            }
         }
         else if (_sceneData->beforeScene == "EditorScene")
         {
-            auto editorToGameData = static_cast<SharedBeatMapData*>(_sceneData);
-            currentBeatMapData_ = editorToGameData->beatMapData; // エディタから渡された譜面データを取得
-            if (currentBeatMapData_.title == "None")
-                currentBeatMapData_.title = "test";
-            gameMode_ = GameMode::EditorTest;
+
+            auto editorToGameData = dynamic_cast<SharedBeatMapData*>(_sceneData);
+            if (editorToGameData)
+            {
+                currentBeatMapData_ = editorToGameData->beatMapData; // エディタから渡された譜面データを取得
+                if (currentBeatMapData_.title == "None")                    currentBeatMapData_.title = "test";
+                gameMode_ = GameMode::EditorTest;
+            }
         }
     }
 

--- a/Application/imgui.ini
+++ b/Application/imgui.ini
@@ -9,10 +9,9 @@ Size=400,400
 Collapsed=0
 
 [Window][Engine]
-Pos=270,19
-Size=1010,701
-Collapsed=0
-DockId=0x00000002,0
+Pos=4,646
+Size=436,128
+Collapsed=1
 
 [Window][Debug]
 Pos=996,19
@@ -31,8 +30,8 @@ Size=425,198
 Collapsed=0
 
 [Window][SceneManager]
-Pos=161,44
-Size=243,246
+Pos=53,54
+Size=159,246
 Collapsed=0
 
 [Window][Timeline]
@@ -58,10 +57,9 @@ Size=120,141
 Collapsed=0
 
 [Window][Emitter]
-Pos=0,19
-Size=268,701
-Collapsed=0
-DockId=0x00000007,0
+Pos=6,671
+Size=268,630
+Collapsed=1
 
 [Window][TextureManager]
 Pos=23,229
@@ -89,8 +87,8 @@ Size=550,680
 Collapsed=0
 
 [Window][Tap BPM Counter]
-Pos=47,51
-Size=500,659
+Pos=323,83
+Size=500,636
 Collapsed=1
 
 [Window][FeedbackEffect Debug]
@@ -127,7 +125,7 @@ Collapsed=0
 DockId=0x0000000B,1
 
 [Window][LightGroup]
-Pos=522,111
+Pos=965,113
 Size=207,215
 Collapsed=0
 
@@ -162,8 +160,8 @@ Size=380,385
 Collapsed=0
 
 [Window][Selected Items]
-Pos=872,71
-Size=214,162
+Pos=735,44
+Size=527,630
 Collapsed=0
 
 [Window][Tab Flags]
@@ -177,14 +175,12 @@ Size=239,157
 Collapsed=0
 
 [Docking][Data]
-DockNode          ID=0x0000000B Pos=711,255 Size=257,272 Selected=0xAA49D574
-DockSpace         ID=0x08BD597D Window=0x1BBC0F80 Pos=0,19 Size=32,32 Split=Y
-  DockNode        ID=0x00000009 Parent=0x08BD597D SizeRef=1280,533 Split=X
-    DockNode      ID=0x00000007 Parent=0x00000009 SizeRef=268,720 Selected=0xFBFB596A
-    DockNode      ID=0x00000008 Parent=0x00000009 SizeRef=1010,720 Split=Y
-      DockNode    ID=0x00000004 Parent=0x00000008 SizeRef=1280,586 Split=X Selected=0xAC437A35
-        DockNode  ID=0x00000002 Parent=0x00000004 SizeRef=994,701 CentralNode=1 Selected=0x9ECF0FAD
-        DockNode  ID=0x00000003 Parent=0x00000004 SizeRef=284,701 Selected=0x1E7E18E3
-      DockNode    ID=0x00000005 Parent=0x00000008 SizeRef=1280,132 Selected=0x42899545
-  DockNode        ID=0x0000000A Parent=0x08BD597D SizeRef=1280,166 Selected=0xB31907B2
+DockNode        ID=0x0000000B Pos=711,255 Size=257,272 Selected=0xAA49D574
+DockSpace       ID=0x08BD597D Window=0x1BBC0F80 Pos=0,19 Size=32,32 Split=Y
+  DockNode      ID=0x00000009 Parent=0x08BD597D SizeRef=1280,533 Split=Y
+    DockNode    ID=0x00000004 Parent=0x00000009 SizeRef=1280,586 Split=X Selected=0xAC437A35
+      DockNode  ID=0x00000002 Parent=0x00000004 SizeRef=994,701 CentralNode=1 Selected=0xF07A5C35
+      DockNode  ID=0x00000003 Parent=0x00000004 SizeRef=284,701 Selected=0x1E7E18E3
+    DockNode    ID=0x00000005 Parent=0x00000009 SizeRef=1280,132 Selected=0x42899545
+  DockNode      ID=0x0000000A Parent=0x08BD597D SizeRef=1280,166 Selected=0xB31907B2
 


### PR DESCRIPTION
Initialize関数の改善

GameCore.cppのInitialize関数にノーツの速度設定を追加しました。
EditorScene.cppおよびGameScene.cppのInitialize関数で、_sceneDataをdynamic_castでキャストし、成功した場合にのみ譜面データやファイルパスを初期化するように変更しました。