### PR TITLE
コンボロジックの実装とResultDSceneへのデータのうけわたし

### DIFF
--- a/Application/Source/Application/Core/GameCore.h
+++ b/Application/Source/Application/Core/GameCore.h
@@ -82,6 +82,25 @@ public:
     /// </summary>
     /// <param name="_speed">ノーツの移動速度</param>
     void SetNoteSpeed(float _speed) { noteSpeed_ = _speed; noteJudge_->SetSpeed(noteSpeed_); }
+
+    /// <summary>
+    /// 最大コンボ数を取得する
+    /// </summary>
+    /// <returns>最大コンボ数</returns>
+    int32_t GetMaxCombo() const { return maxCombo_; }
+
+    /// <summary>
+    /// 現在のコンボ数を取得する
+    /// </summary>
+    /// <returns>現在のコンボ数</returns>
+    int32_t GetCombo() const { return combo_; }
+
+    /// <summary>
+    /// 判定結果を取得する
+    /// </summary>
+    /// <returns>判定結果のマップ</returns>
+    std::map<JudgeType, uint32_t> GetJudgeResult() const { return judgeResult_->GetJudgeResult(); }
+
 private:
 
     void JudgeNotes(const std::vector<InputDate>& _inputData);
@@ -110,6 +129,10 @@ private:
     // score あとまわし
 
     // note spawner あったらいいな
+
+    // コンボ
+    int32_t combo_ = 0; // 現在のコンボ数
+    int32_t maxCombo_ = 0; // 最大コンボ数
 
     //-------------------------
     // コールバック関連

--- a/Application/Source/Application/Result/UI/ResultUI.cpp
+++ b/Application/Source/Application/Result/UI/ResultUI.cpp
@@ -29,7 +29,7 @@ void ResultUI::Initialize(ResultData _resultData)
         if (!param.counterValue.has_value())
             param.counterValue = std::make_optional<CounterValue>();
 
-        if (param.counterValue->value == 0)
+        if (param.counterValue->value == -1)
             param.counterValue->value = 192;
     }
 #endif // _DEBUG

--- a/Application/Source/Application/Scene/GameScene.cpp
+++ b/Application/Source/Application/Scene/GameScene.cpp
@@ -202,7 +202,15 @@ void GameScene::Update()
     if (IsMusicEnd())
     {
         if(isTransitionToResultScene_)
-            SceneManager::ReserveScene("ResultScene", nullptr);
+        {
+            auto data = std::make_unique<GameToResultData>();
+            data->resultData.musicTitle = beatMapLoader_->GetLoadedBeatMapData().title; // 譜面のタイトルを取得
+            data->resultData.combo = gameCore_->GetMaxCombo();
+            data->resultData.score = gameCore_->GetMaxCombo() * 100; // 仮のスコア計算
+            data->resultData.judgeResult = gameCore_->GetJudgeResult();
+
+            SceneManager::ReserveScene("ResultScene", std::move(data)); // 結果シーンにデータを渡す
+        }
     }
 
     if (gameMode_ == GameMode::EditorTest)
@@ -375,13 +383,15 @@ void GameScene::ImGui()
         gameEnvironment_->StartAnimation();
 
 
-    if(ImGuiDebugManager::GetInstance()->Begin("GameScene"))
-
+    if (input_->IsKeyTriggered(DIK_F1))
     {
-        if (input_->IsKeyTriggered(DIK_F1))
-        {
-            enableDebugCamera_ = !enableDebugCamera_;
-        }
+        enableDebugCamera_ = !enableDebugCamera_;
+    }
+    if(ImGuiDebugManager::GetInstance()->Begin("GameScene"))
+    {
+        ImGui::Text("combo: %d", gameCore_->GetCombo());
+        ImGui::Text("maxCombo: %d", gameCore_->GetMaxCombo());
+
         float time = voiceInstance_->GetElapsedTime();
         ImGui::Text("Elapsed Time: %.2f", time);
 

--- a/Application/Source/Application/Scene/ResultScene.cpp
+++ b/Application/Source/Application/Scene/ResultScene.cpp
@@ -28,6 +28,12 @@ void ResultScene::Initialize(SceneData* _sceneData)
     // ------------------
     // application
 
+    resultData_.judgeResult[JudgeType::Perfect] = -1;
+    resultData_.judgeResult[JudgeType::Good] = -1;
+    resultData_.judgeResult[JudgeType::Bad] = -1;
+    resultData_.judgeResult[JudgeType::Miss] = -1;
+
+
     if (_sceneData)
     {
         auto data = dynamic_cast<GameToResultData*>(_sceneData);

--- a/Application/imgui.ini
+++ b/Application/imgui.ini
@@ -30,7 +30,7 @@ Size=425,198
 Collapsed=0
 
 [Window][SceneManager]
-Pos=266,44
+Pos=70,19
 Size=206,246
 Collapsed=0
 


### PR DESCRIPTION
- `GameCore` クラスのコンストラクタでメンバ変数を初期化リストを使用して初期化
- `GameCore::Initialize` メソッドでコンボ数と最大コンボ数の初期化を追加
- `GameCore::Update` メソッドでノーツ削除時のコンボリセット処理を追加
- `GameCore::JudgeNotes` メソッドで判定に応じたコンボ数の更新処理を追加
- `GameCore.h` にコンボ数と最大コンボ数を取得するゲッターを追加
- `GameCore.h` にコンボ数と最大コンボ数を保持するメンバ変数を追加
- `ResultUI::Initialize` メソッドでカウンター値の初期設定を変更
- `GameScene::Update` メソッドで結果シーンに渡すデータにコンボ数、スコア、判定結果を追加
- `GameScene::ImGui` メソッドでコンボ数と最大コンボ数を表示するテキストを追加
- `ResultScene::Initialize` メソッドで判定結果の初期値を設定