### PR TITLE
リザルトのボタンの処理を追加

### DIFF
--- a/Application/Source/Application/Result/UI/ResultUI.cpp
+++ b/Application/Source/Application/Result/UI/ResultUI.cpp
@@ -11,8 +11,8 @@ void ResultUI::Initialize(ResultData _resultData)
     textParams_[TextType::Score_value].counterValue = std::make_optional<CounterValue>();
     textParams_[TextType::Score_value].counterValue->value = _resultData.score;
 
-    textParams_[TextType::Score_value].counterValue = std::make_optional<CounterValue>();
-    textParams_[TextType::Score_value].counterValue->value = _resultData.score;
+    textParams_[TextType::Combo_value].counterValue = std::make_optional<CounterValue>();
+    textParams_[TextType::Combo_value].counterValue->value = _resultData.combo;
 
     for (auto& [judgeType, count] : _resultData.judgeResult)
     {
@@ -192,7 +192,19 @@ void ResultUI::InitUIGroup()
     auto mainBg = uiGroup_->CreateSprite("main_bg");
 
     auto toTitleButton = uiGroup_->CreateButton("To_Title");
+
+    toTitleButton->SetCallBackOnClickEnd([this]()
+        {
+            transitionToTitle_ = true;
+        });
+
     auto retryButton = uiGroup_->CreateButton("Retry");
+
+    retryButton->SetCallBackOnClickEnd([this]()
+        {
+            replay_ = true;
+        });
+
 
     UIGroup::LinkHorizontal({ toTitleButton, retryButton });
 

--- a/Application/Source/Application/Result/UI/ResultUI.h
+++ b/Application/Source/Application/Result/UI/ResultUI.h
@@ -28,6 +28,8 @@ public:
     // 描画
     void Draw();
 
+    bool IsTransitionToTitle() const { return transitionToTitle_; }
+    bool IsReplay() const { return replay_; }
 
 private:
 
@@ -103,16 +105,16 @@ private:
         float animationTimer = 0.0f; // アニメーションタイマー
     };
 
-
     float animationDuration_ = 0.25f;
+    std::unique_ptr<AnimationSequence> animationSequence_ = nullptr; // アニメーションシーケンス
 
     std::unique_ptr<UIGroup> uiGroup_ = nullptr; // UIグループ
+
 #ifdef _DEBUG
     std::vector<UISprite*> debugSprites_; // デバッグ用スプライト
     std::vector<UIButton*> debugButtons_; // デバッグ用ボタン
 #endif // _DEBUG
 
-    std::unique_ptr<AnimationSequence> animationSequence_ = nullptr; // アニメーションシーケンス
 
     // textParamの拡張
     struct ExtendedTextParam
@@ -126,4 +128,7 @@ private:
     std::map<TextType, ExtendedTextParam> textParams_; // テキストパラメータのマップ
 
     std::unique_ptr<JsonBinder> jsonBinder_ = nullptr; // JSONバインダー
+
+    bool transitionToTitle_ = false; // タイトルへ遷移するかどうか
+    bool replay_ = false; // リプレイするかどうか
 };

--- a/Application/Source/Application/Scene/ResultScene.cpp
+++ b/Application/Source/Application/Scene/ResultScene.cpp
@@ -1,6 +1,7 @@
 #include "ResultScene.h"
 
 #include <Application/Scene/Data/SceneDatas.h>
+#include <Features/Scene/Manager/SceneManager.h>
 
 void ResultScene::Initialize(SceneData* _sceneData)
 {
@@ -62,6 +63,15 @@ void ResultScene::Update()
 
     resultUI_->Update(static_cast<float>(GameTime::GetInstance()->GetDeltaTime()));
 
+
+    if (resultUI_->IsTransitionToTitle())
+    {
+        SceneManager::GetInstance()->ReserveScene("TitleScene", nullptr);
+    }
+    else if (resultUI_->IsReplay())
+    {
+        SceneManager::GetInstance()->ReserveScene("GameScene", nullptr);
+    }
 
     if (enableDebugCamera_)
     {


### PR DESCRIPTION
- `ResultUI::Initialize` メソッドにコンボの初期化を追加
- `ResultUI::InitUIGroup` メソッドにタイトル戻りボタンとリトライボタンを追加し、コールバックを設定
- `ResultUI.h` に `IsTransitionToTitle` と `IsReplay` メソッドを追加
- `ResultScene.cpp` に `SceneManager` のインクルードを追加し、`Update` メソッドでシーン遷移を実装
- エンジンのサブプロジェクトのコミットIDを更新