### PR TITLE
TextRendererからTextGeneratorへの移行

### DIFF
--- a/Application/Source/Application/BeatMapEditor/BeatMapEditor.cpp
+++ b/Application/Source/Application/BeatMapEditor/BeatMapEditor.cpp
@@ -32,7 +32,7 @@ void BeatMapEditor::Initialize(const BeatMapData& _beatMapData)
 {
     input_ = Input::GetInstance();
     lineDrawer_ = LineDrawer::GetInstance();
-    textRenderer_ = TextRenderer::GetInstance();
+    text_.Initialize(FontConfig());
 
 
 
@@ -756,7 +756,7 @@ void BeatMapEditor::DrawTimeline()
     timelineSprites_["end"]->Draw();
     timelineSprites_["playhead"]->Draw();
     timelineSprites_["toTestButton"]->Draw();
-    textRenderer_->DrawText(L"テスト", textParam_);
+    text_.Draw(L"テスト", textParam_);
 }
 
 

--- a/Application/Source/Application/BeatMapEditor/BeatMapEditor.h
+++ b/Application/Source/Application/BeatMapEditor/BeatMapEditor.h
@@ -5,7 +5,7 @@
 #include <Features/LineDrawer/LineDrawer.h>
 #include <System/Audio/SoundInstance.h>
 #include <System/Audio/VoiceInstance.h>
-#include <Features/TextRenderer/TextRenderer.h>
+#include <Features/TextRenderer/TextGenerator.h>
 
 
 #include <Application/BeatMapEditor/EditorCoordinate.h>
@@ -350,9 +350,9 @@ private:
     LineDrawer* lineDrawer_ = nullptr;
     Input* input_ = nullptr;
     Camera for2dCamera_;
-    TextRenderer* textRenderer_ = nullptr;
     BeatMapLoader* beatMapLoader_ = nullptr;
     std::unique_ptr<BeatManager> beatManager_ = nullptr;
+    TextGenerator text_;
     bool enableBeats_ = false;
 
     // ========================================
@@ -458,6 +458,8 @@ private:
     std::unique_ptr<UISprite> dummy_editLaneArea_;
     std::unique_ptr<UISprite> dummy_window_;
     std::unique_ptr<UISprite> dummy_editArea_;
+
+
 
     // ========================================
     // 特殊機能

--- a/Application/Source/Application/FeedBack/JudgeText/JudgeText.cpp
+++ b/Application/Source/Application/FeedBack/JudgeText/JudgeText.cpp
@@ -14,7 +14,7 @@ JudgeText::JudgeText():
     alpha_(1.0f), // 初期アルファ値を設定
     scale_(1.0f, 1.0f), // 初期スケールを設定
     displayDuration_(1.0f), // 初期表示時間を設定
-    textRenderer_(TextRenderer::GetInstance()) // テキストレンダラーのインスタンスを取得
+    text_({}) // テキストレンダラーのインスタンスを取得
 {
 }
 
@@ -36,8 +36,7 @@ void JudgeText::Initialize(JudgeType _judgeType, int32_t _laneIndex, const Camer
     judgeText_ = GetJudgeText(judgeType_); // 判定テキストの初期化
     GetJudgeTextColor(judgeType_, topColor_, bottomColor_); // 判定テキストの色を取得
 
-    if(!textRenderer_)
-        textRenderer_ = TextRenderer::GetInstance(); // テキストレンダラーのインスタンスを取得
+    text_.Initialize(FontConfig()); // テキストレンダラーの初期化
 
     animationSequence_ = std::make_unique<AnimationSequence>("JudgeTextAnimation");
     animationSequence_->Initialize("Resources/Data/AnimSeq/"); // アニメーションシーケンスの初期化
@@ -62,7 +61,7 @@ void JudgeText::Update(float _deltaTime)
 
 void JudgeText::Draw()
 {
-    textRenderer_->DrawText(judgeText_, textParam_);
+    text_.Draw(judgeText_, textParam_);
 }
 
 void JudgeText::AnimateText()

--- a/Application/Source/Application/FeedBack/JudgeText/JudgeText.h
+++ b/Application/Source/Application/FeedBack/JudgeText/JudgeText.h
@@ -3,7 +3,7 @@
 #include <Math/Vector/Vector3.h>
 #include <Math/Vector/Vector4.h>
 #include <Features/Animation/Sequence/AnimationSequence.h>
-#include <Features/TextRenderer/TextRenderer.h>
+#include <Features/TextRenderer/TextGenerator.h>
 
 #include <Application/Note/Judge/JudgeType.h>
 
@@ -73,7 +73,7 @@ private:
     static float displayYOffset_; // Y軸のオフセット
 private:
 
-    TextRenderer* textRenderer_ = nullptr; // テキストレンダラー
+    TextGenerator text_;
 
     JudgeType judgeType_; // 判定タイプ
 

--- a/Application/Source/Application/Result/UI/ResultUI.cpp
+++ b/Application/Source/Application/Result/UI/ResultUI.cpp
@@ -42,6 +42,7 @@ void ResultUI::Initialize(ResultData _resultData)
     InitUIGroup();
     InitTextParams();
 
+    text_.Initialize(FontConfig());
 }
 
 
@@ -180,7 +181,7 @@ void ResultUI::Draw()
             break;
 
         // テキストの描画
-        TextRenderer::GetInstance()->DrawText(param.label, param.textParam);
+        text_.Draw(param.label, param.textParam);
     }
 }
 

--- a/Application/Source/Application/Result/UI/ResultUI.h
+++ b/Application/Source/Application/Result/UI/ResultUI.h
@@ -7,7 +7,7 @@
 #include <Features/Animation/Sequence/AnimationSequence.h>
 #include <Features/Json/JsonBinder.h>
 
-#include <Features/TextRenderer/TextRenderer.h>
+#include <Features/TextRenderer/TextGenerator.h>
 
 #include <Application/Result/ResultData.h>
 
@@ -131,4 +131,6 @@ private:
 
     bool transitionToTitle_ = false; // タイトルへ遷移するかどうか
     bool replay_ = false; // リプレイするかどうか
+
+    TextGenerator text_; // テキストジェネレータ
 };

--- a/Application/Source/Application/Scene/SelectScene.cpp
+++ b/Application/Source/Application/Scene/SelectScene.cpp
@@ -26,7 +26,7 @@ void SelectScene::Initialize(SceneData* _sceneData)
     lightGroup_ = std::make_shared<LightGroup>();
     lightGroup_->Initialize();
 
-    textRenderer_ = TextRenderer::GetInstance();
+    text_.Initialize(FontConfig());
 
 
     LightingSystem::GetInstance()->SetActiveGroup(lightGroup_);
@@ -90,10 +90,10 @@ void SelectScene::Update()
         .SetPosition({ 640, 200 })
         .SetScale({ 1.0f, 1.0f });
 
-    textRenderer_->DrawText(L"せれくとしーん", param);
+    text_.Draw(L"せれくとしーん", param);
 
     param.SetPosition({ 640, 360 });
-    textRenderer_->DrawText(L"譜面ファイル選択(仮)", param);
+    text_.Draw(L"譜面ファイル選択(仮)", param);
 }
 
 void SelectScene::Draw()

--- a/Application/Source/Application/Scene/SelectScene.h
+++ b/Application/Source/Application/Scene/SelectScene.h
@@ -7,7 +7,7 @@
 #include <Features/LineDrawer/LineDrawer.h>
 #include <System/Time/Stopwatch.h>
 #include <Features/Effect/Manager/ParticleSystem.h>
-#include <Features/TextRenderer/TextRenderer.h>
+#include <Features/TextRenderer/TextGenerator.h>
 
 #include <Features/UI/UIButton.h>
 
@@ -35,7 +35,7 @@ private:
     Input* input_ = nullptr;
     ParticleSystem* particleSystem_ = nullptr;
 
-    TextRenderer* textRenderer_ = nullptr;
+    TextGenerator text_;
 
     std::shared_ptr<LightGroup> lightGroup_ = nullptr;
 

--- a/Application/Source/Essential/SampleFramework.cpp
+++ b/Application/Source/Essential/SampleFramework.cpp
@@ -18,10 +18,6 @@ void SampleFramework::Initialize(const std::wstring& _winTitle)
 
     sceneManager_->SetSceneFactory(new SceneFactory());
 
-    textRenderer_->Initialize(dxCommon_->GetDevice(), dxCommon_->GetCommandList(),
-        TextRenderer::Config{ { 4096, 4096 }, 32.0f, "Resources/Fonts/NotoSansJP-Regular.ttf" },
-        Vector2(static_cast<float>(WinApp::kWindowWidth_), static_cast<float>(WinApp::kWindowHeight_)));
-
     particleManager_->SetModifierFactory(new ParticleModifierFactory());
 
     collisionManager_->Initialize(Vector2(100, 100), 5, Vector2(-50, -50), 1.0f);


### PR DESCRIPTION
- BeatMapEditor.cppでTextRendererをTextGeneratorに変更し、text_オブジェクトを使用してテキストを描画するように更新。
- JudgeText.cppでも同様にTextRendererからTextGeneratorに移行し、テキストの初期化と描画をtext_オブジェクトを通じて行うように変更。
- ResultUI.cppおよびSelectScene.cppでもTextRendererをTextGeneratorに置き換え、テキスト描画をtext_オブジェクトを使用して実施。
- ヘッダーファイルでTextRendererのインクルードをTextGeneratorに変更し、関連するメンバー変数も更新。
- SampleFramework.cppでTextRendererの初期化コードを削除し、TextGeneratorへの移行準備を完了。