### PR TITLE
TrigerEffectを分離してtapじにエフェクトが出るようにした

### DIFF
--- a/Application/RhythmProject.vcxproj
+++ b/Application/RhythmProject.vcxproj
@@ -115,6 +115,7 @@
     <ClCompile Include="Source\Application\FeedBack\JudgeText\JudgeText.cpp" />
     <ClCompile Include="Source\Application\FeedBack\LaneEffect\LaneEffect.cpp" />
     <ClCompile Include="Source\Application\FeedBack\MissedVignette\MissedVignette.cpp" />
+    <ClCompile Include="Source\Application\FeedBack\TapEffect\TapEffect.cpp" />
     <ClCompile Include="Source\Application\GameEnvironment\GameEnvironment.cpp" />
     <ClCompile Include="Source\Application\GameUI\GameUI.cpp" />
     <ClCompile Include="Source\Application\Input\GameInputManager.cpp" />
@@ -166,6 +167,7 @@
     <ClInclude Include="Source\Application\FeedBack\JudgeText\JudgeText.h" />
     <ClInclude Include="Source\Application\FeedBack\LaneEffect\LaneEffect.h" />
     <ClInclude Include="Source\Application\FeedBack\MissedVignette\MissedVignette.h" />
+    <ClInclude Include="Source\Application\FeedBack\TapEffect\TapEffect.h" />
     <ClInclude Include="Source\Application\GameEnvironment\GameEnvironment.h" />
     <ClInclude Include="Source\Application\GameUI\GameUI.h" />
     <ClInclude Include="Source\Application\Input\GameInputManager.h" />

--- a/Application/RhythmProject.vcxproj.filters
+++ b/Application/RhythmProject.vcxproj.filters
@@ -37,17 +37,8 @@
     <Filter Include="Application\FeedBack">
       <UniqueIdentifier>{15913ee5-bced-4b13-9693-e57cfca2a57f}</UniqueIdentifier>
     </Filter>
-    <Filter Include="Application\FeedBack\JudgeSound">
-      <UniqueIdentifier>{657fcfb3-623c-44e3-b1bc-d0b9cc00f822}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Application\FeedBack\JudgeEffect">
-      <UniqueIdentifier>{65add205-d443-47ac-99fc-3ea6b04894b7}</UniqueIdentifier>
-    </Filter>
     <Filter Include="Application\BeatMapEditor\BPMCounter">
       <UniqueIdentifier>{8d1b859e-d15f-4c03-8e79-72e0bc68b5ae}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Application\FeedBack\JudgeText">
-      <UniqueIdentifier>{36b0ddf2-e0a1-4bb5-8294-02092c09ea62}</UniqueIdentifier>
     </Filter>
     <Filter Include="Application\BeatMapEditor\Command">
       <UniqueIdentifier>{a4cdee18-3ed8-4f63-8471-4cf980f84c4a}</UniqueIdentifier>
@@ -57,12 +48,6 @@
     </Filter>
     <Filter Include="Application\Environment">
       <UniqueIdentifier>{3270d924-6385-41eb-a1e7-adc5b2108b38}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Application\FeedBack\LaneEffect">
-      <UniqueIdentifier>{8d76655d-dae6-4ce7-b884-14bd6cb43774}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Application\FeedBack\TapEffects">
-      <UniqueIdentifier>{1becb388-379b-4a7f-a968-049ec8f0f527}</UniqueIdentifier>
     </Filter>
     <Filter Include="Application\Result">
       <UniqueIdentifier>{e8f93c9b-9596-4e37-bf76-9fc7d4f79075}</UniqueIdentifier>
@@ -93,6 +78,30 @@
     </Filter>
     <Filter Include="Application\FeedBack\MissedVignette">
       <UniqueIdentifier>{c684dc34-a1f7-469e-b109-12b541e03171}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Application\FeedBack\Judge">
+      <UniqueIdentifier>{ac6102ff-aa48-411e-9d58-217845cd0043}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Application\FeedBack\Judge\Effect">
+      <UniqueIdentifier>{65add205-d443-47ac-99fc-3ea6b04894b7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Application\FeedBack\Judge\Sound">
+      <UniqueIdentifier>{657fcfb3-623c-44e3-b1bc-d0b9cc00f822}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Application\FeedBack\Judge\Text">
+      <UniqueIdentifier>{36b0ddf2-e0a1-4bb5-8294-02092c09ea62}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Application\FeedBack\Tap">
+      <UniqueIdentifier>{99978e57-8bad-41ac-ad36-02a7eab374e2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Application\FeedBack\Tap\LaneEffect">
+      <UniqueIdentifier>{8d76655d-dae6-4ce7-b884-14bd6cb43774}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Application\FeedBack\Effect">
+      <UniqueIdentifier>{a527790c-6254-4efe-a512-825a566507de}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Application\FeedBack\Tap\Effect">
+      <UniqueIdentifier>{1becb388-379b-4a7f-a968-049ec8f0f527}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
@@ -127,17 +136,8 @@
     <ClCompile Include="Source\Application\BeatMapLoader\BeatMapLoader.cpp">
       <Filter>Application\BeatMapLoader</Filter>
     </ClCompile>
-    <ClCompile Include="Source\Application\Effects\TapEffects\TriggerEffects.cpp">
-      <Filter>Application\FeedBack\TapEffects</Filter>
-    </ClCompile>
-    <ClCompile Include="Source\Application\Effects\TapEffects\HitparticleModifier.cpp">
-      <Filter>Application\FeedBack\TapEffects</Filter>
-    </ClCompile>
     <ClCompile Include="Source\Essential\ParticleModifierFactory.cpp">
       <Filter>Essential</Filter>
-    </ClCompile>
-    <ClCompile Include="Source\Application\Effects\TapEffects\LightPillarModifier.cpp">
-      <Filter>Application\FeedBack\TapEffects</Filter>
     </ClCompile>
     <ClCompile Include="Source\Application\Scene\TitleScene.cpp">
       <Filter>Application\Scene</Filter>
@@ -170,7 +170,7 @@
       <Filter>Application\Scene\SceneTransition</Filter>
     </ClCompile>
     <ClCompile Include="Source\Application\FeedBack\JudgeSound\JudgeSound.cpp">
-      <Filter>Application\FeedBack\JudgeSound</Filter>
+      <Filter>Application\FeedBack\Judge\Sound</Filter>
     </ClCompile>
     <ClCompile Include="Source\Application\FeedBack\FeedbackEffect.cpp">
       <Filter>Application\FeedBack</Filter>
@@ -179,7 +179,7 @@
       <Filter>Application\BeatMapEditor\BPMCounter</Filter>
     </ClCompile>
     <ClCompile Include="Source\Application\FeedBack\JudgeText\JudgeText.cpp">
-      <Filter>Application\FeedBack\JudgeText</Filter>
+      <Filter>Application\FeedBack\Judge\Text</Filter>
     </ClCompile>
     <ClCompile Include="Source\Application\Command\CommandHistory.cpp">
       <Filter>Application\BeatMapEditor\Command\Core</Filter>
@@ -206,7 +206,7 @@
       <Filter>Application\Environment</Filter>
     </ClCompile>
     <ClCompile Include="Source\Application\FeedBack\JudgeEffect\JudgeEffect.cpp">
-      <Filter>Application\FeedBack\JudgeEffect</Filter>
+      <Filter>Application\FeedBack\Judge\Effect</Filter>
     </ClCompile>
     <ClCompile Include="Source\Application\Result\UI\ResultUI.cpp">
       <Filter>Application\ResultUI</Filter>
@@ -221,7 +221,19 @@
       <Filter>Application\FeedBack\MissedVignette</Filter>
     </ClCompile>
     <ClCompile Include="Source\Application\FeedBack\LaneEffect\LaneEffect.cpp">
-      <Filter>Application\FeedBack\LaneEffect</Filter>
+      <Filter>Application\FeedBack\Tap\LaneEffect</Filter>
+    </ClCompile>
+    <ClCompile Include="Source\Application\Effects\TapEffects\HitparticleModifier.cpp">
+      <Filter>Application\FeedBack\Effect</Filter>
+    </ClCompile>
+    <ClCompile Include="Source\Application\Effects\TapEffects\LightPillarModifier.cpp">
+      <Filter>Application\FeedBack\Effect</Filter>
+    </ClCompile>
+    <ClCompile Include="Source\Application\Effects\TapEffects\TriggerEffects.cpp">
+      <Filter>Application\FeedBack\Effect</Filter>
+    </ClCompile>
+    <ClCompile Include="Source\Application\FeedBack\TapEffect\TapEffect.cpp">
+      <Filter>Application\FeedBack\Tap\Effect</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -258,17 +270,8 @@
     <ClInclude Include="Source\Application\BeatMapLoader\BeatMapData.h">
       <Filter>Application\BeatMapLoader</Filter>
     </ClInclude>
-    <ClInclude Include="Source\Application\Effects\TapEffects\HitparticleModifier.h">
-      <Filter>Application\FeedBack\TapEffects</Filter>
-    </ClInclude>
-    <ClInclude Include="Source\Application\Effects\TapEffects\TriggerEffects.h">
-      <Filter>Application\FeedBack\TapEffects</Filter>
-    </ClInclude>
     <ClInclude Include="Source\Essential\ParticleModifierFactory.h">
       <Filter>Essential</Filter>
-    </ClInclude>
-    <ClInclude Include="Source\Application\Effects\TapEffects\LightPillarModifier.h">
-      <Filter>Application\FeedBack\TapEffects</Filter>
     </ClInclude>
     <ClInclude Include="Source\Application\Scene\TitleScene.h">
       <Filter>Application\Scene</Filter>
@@ -313,19 +316,19 @@
       <Filter>Application\Scene\SceneTransition</Filter>
     </ClInclude>
     <ClInclude Include="Source\Application\FeedBack\JudgeSound\JudgeSound.h">
-      <Filter>Application\FeedBack\JudgeSound</Filter>
+      <Filter>Application\FeedBack\Judge\Sound</Filter>
     </ClInclude>
     <ClInclude Include="Source\Application\FeedBack\FeedbackEffect.h">
       <Filter>Application\FeedBack</Filter>
     </ClInclude>
     <ClInclude Include="Source\Application\FeedBack\JudgeEffect\JudgeEffect.h">
-      <Filter>Application\FeedBack\JudgeEffect</Filter>
+      <Filter>Application\FeedBack\Judge\Effect</Filter>
     </ClInclude>
     <ClInclude Include="Source\Application\BeatMapEditor\BPMCounter\TapBPMCounter.h">
       <Filter>Application\BeatMapEditor\BPMCounter</Filter>
     </ClInclude>
     <ClInclude Include="Source\Application\FeedBack\JudgeText\JudgeText.h">
-      <Filter>Application\FeedBack\JudgeText</Filter>
+      <Filter>Application\FeedBack\Judge\Text</Filter>
     </ClInclude>
     <ClInclude Include="Source\Application\Command\CommandHistory.h">
       <Filter>Application\BeatMapEditor\Command\Core</Filter>
@@ -370,7 +373,19 @@
       <Filter>Application\FeedBack\MissedVignette</Filter>
     </ClInclude>
     <ClInclude Include="Source\Application\FeedBack\LaneEffect\LaneEffect.h">
-      <Filter>Application\FeedBack\LaneEffect</Filter>
+      <Filter>Application\FeedBack\Tap\LaneEffect</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\Application\Effects\TapEffects\HitparticleModifier.h">
+      <Filter>Application\FeedBack\Effect</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\Application\Effects\TapEffects\LightPillarModifier.h">
+      <Filter>Application\FeedBack\Effect</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\Application\Effects\TapEffects\TriggerEffects.h">
+      <Filter>Application\FeedBack\Effect</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\Application\FeedBack\TapEffect\TapEffect.h">
+      <Filter>Application\FeedBack\Tap\Effect</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Application/Source/Application/FeedBack/FeedbackEffect.cpp
+++ b/Application/Source/Application/FeedBack/FeedbackEffect.cpp
@@ -14,6 +14,9 @@ void FeedbackEffect::Initialize(Camera* _camera, int32_t _laneCount)
     judgeEffect_ = std::make_unique<JudgeEffect>();
     judgeEffect_->Initialize();
 
+    tapEffect_ = std::make_unique<TapEffect>();
+    tapEffect_->Initialize();
+
     for (int32_t i = 0; i < judgeTextPool_.size(); ++i)
     {
         judgeTextPool_[i] = std::make_unique<JudgeText>();
@@ -61,7 +64,10 @@ void FeedbackEffect::Update(float _deltaTime, const std::vector<InputDate>& _inp
     for (const auto& input : _inputData)
     {
         if (input.state == KeyState::trigger || input.state == KeyState::Hold)
+        {
             laneEffects_[input.laneIndex]->Start();
+            tapEffect_->Play(input.laneIndex);
+        }
     }
 
     for (auto& laneEffect : laneEffects_)

--- a/Application/Source/Application/FeedBack/FeedbackEffect.h
+++ b/Application/Source/Application/FeedBack/FeedbackEffect.h
@@ -6,6 +6,7 @@
 #include <Application/FeedBack/JudgeText/JudgeText.h>
 #include <Application/FeedBack/MissedVignette/MissedVignette.h>
 #include <Application/FeedBack/LaneEffect/LaneEffect.h>
+#include <Application/FeedBack/TapEffect/TapEffect.h>
 
 #include <Application/Input/InputData.h>
 
@@ -63,6 +64,7 @@ private:
 
     /// パーティクル
     std::unique_ptr<JudgeEffect> judgeEffect_;
+    std::unique_ptr<TapEffect> tapEffect_; // タップエフェクト
 
     /// 判定テキスト
     static const int32_t kMaxJudgeTexts_ = 10; // 最大の判定テキスト数

--- a/Application/Source/Application/FeedBack/JudgeEffect/JudgeEffect.cpp
+++ b/Application/Source/Application/FeedBack/JudgeEffect/JudgeEffect.cpp
@@ -12,9 +12,6 @@ void JudgeEffect::Play(int32_t _laneIndex)
 {
     Vector3  lanePos = Lane::GetLaneEndPosition(_laneIndex); // レーンの開始位置を取得
 
-    // 中心の円を発生させる
-    TriggerEffects::EmitCenterCircles(lanePos);
-
     // 周囲のパーティクルを発生させる
     TriggerEffects::EmitSurroundingParticles(lanePos);
 

--- a/Application/Source/Application/FeedBack/TapEffect/TapEffect.cpp
+++ b/Application/Source/Application/FeedBack/TapEffect/TapEffect.cpp
@@ -1,0 +1,18 @@
+#include "TapEffect.h"
+
+#include <Application/Lane/Lane.h>
+#include <Application/Effects/TapEffects/TriggerEffects.h>
+
+void TapEffect::Initialize()
+{
+    TriggerEffects::Initialize();
+}
+
+void TapEffect::Play(int32_t _laneIndex)
+{
+    Vector3  lanePos = Lane::GetLaneEndPosition(_laneIndex); // レーンの開始位置を取得
+
+    // 中心の円を発生させる
+    TriggerEffects::EmitCenterCircles(lanePos);
+
+}

--- a/Application/Source/Application/FeedBack/TapEffect/TapEffect.h
+++ b/Application/Source/Application/FeedBack/TapEffect/TapEffect.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <cstdint>
+
+class TapEffect
+{
+public:
+    TapEffect() = default;
+    ~TapEffect() = default;
+
+    void Initialize();
+
+    /// <summary>
+    /// エフェクトを再生
+    /// </summary>
+    void Play(int32_t _laneIndex);
+
+private:
+
+
+};

--- a/Application/Source/Application/Scene/TitleScene.cpp
+++ b/Application/Source/Application/Scene/TitleScene.cpp
@@ -25,6 +25,7 @@ void TitleScene::Initialize(SceneData* _sceneData)
 
     LightingSystem::GetInstance()->SetActiveGroup(lightGroup_);
 
+    textGenerator_.Initialize(FontConfig(Vector2(1024, 1024), 64));
 
 
 }
@@ -62,7 +63,8 @@ void TitleScene::Update()
 
     particleSystem_->Update();
 
-
+    textGenerator_.Draw(L"音ゲー", Vector2(640, 200));
+    textGenerator_.Draw(L"Press Space", Vector2(640, 500));
 
 }
 

--- a/Application/Source/Application/Scene/TitleScene.h
+++ b/Application/Source/Application/Scene/TitleScene.h
@@ -8,6 +8,7 @@
 #include <System/Time/Stopwatch.h>
 #include <Features/Effect/Manager/ParticleSystem.h>
 
+#include <Features/TextRenderer/TextGenerator.h>
 
 class TitleScene : public BaseScene
 {
@@ -35,5 +36,11 @@ private:
 
     std::shared_ptr<LightGroup> lightGroup_ = nullptr;
 
+
+    /// ---------------------------------
+    ///     application
+
+
+    TextGenerator textGenerator_;
 
 };

--- a/Application/Source/Essential/SampleFramework.cpp
+++ b/Application/Source/Essential/SampleFramework.cpp
@@ -29,7 +29,7 @@ void SampleFramework::Initialize(const std::wstring& _winTitle)
     LayerSystem::Initialize();
 
     // 最初のシーンで初期化
-    sceneManager_->Initialize("Sample");
+    sceneManager_->Initialize("TitleScene");
 }
 
 void SampleFramework::Update()


### PR DESCRIPTION
- `TapEffect`に関連するソースファイルとヘッダーファイルを追加
- `FeedbackEffect`クラスに`TapEffect`のインスタンスを追加し、初期化と再生を実装
- `JudgeEffect`、`JudgeSound`、`JudgeText`のフィルターを新しい階層`Application\FeedBack\Judge`に整理
- 古い`TapEffects`フィルターを削除し、新しい構造に合わせて整理
- `TitleScene`クラスに`TextGenerator`を追加し、テキスト描画機能を強化
- `SampleFramework`の初期化時に最初のシーンを`Sample`から`TitleScene`に変更