### PR TITLE
ポーズメニューのボタン機能実装と音楽管理の改善

### DIFF
--- a/Application/RhythmProject.vcxproj
+++ b/Application/RhythmProject.vcxproj
@@ -117,6 +117,7 @@
     <ClCompile Include="Source\Application\FeedBack\MissedVignette\MissedVignette.cpp" />
     <ClCompile Include="Source\Application\FeedBack\TapEffect\TapEffect.cpp" />
     <ClCompile Include="Source\Application\GameEnvironment\GameEnvironment.cpp" />
+    <ClCompile Include="Source\Application\GameMusic\GameMusic.cpp" />
     <ClCompile Include="Source\Application\GameUI\GameUI.cpp" />
     <ClCompile Include="Source\Application\Input\GameInputManager.cpp" />
     <ClCompile Include="Source\Application\Lane\Lane.cpp" />
@@ -162,6 +163,7 @@
     <ClInclude Include="Source\Application\Effects\TapEffects\HitparticleModifier.h" />
     <ClInclude Include="Source\Application\Effects\TapEffects\LightPillarModifier.h" />
     <ClInclude Include="Source\Application\Effects\TapEffects\TriggerEffects.h" />
+    <ClInclude Include="Source\Application\EventData\PauseActionData.h" />
     <ClInclude Include="Source\Application\FeedBack\FeedbackEffect.h" />
     <ClInclude Include="Source\Application\FeedBack\JudgeEffect\JudgeEffect.h" />
     <ClInclude Include="Source\Application\FeedBack\JudgeSound\JudgeSound.h" />
@@ -170,6 +172,7 @@
     <ClInclude Include="Source\Application\FeedBack\MissedVignette\MissedVignette.h" />
     <ClInclude Include="Source\Application\FeedBack\TapEffect\TapEffect.h" />
     <ClInclude Include="Source\Application\GameEnvironment\GameEnvironment.h" />
+    <ClInclude Include="Source\Application\GameMusic\GameMusic.h" />
     <ClInclude Include="Source\Application\GameUI\GameUI.h" />
     <ClInclude Include="Source\Application\Input\GameInputManager.h" />
     <ClInclude Include="Source\Application\Input\InputData.h" />

--- a/Application/RhythmProject.vcxproj.filters
+++ b/Application/RhythmProject.vcxproj.filters
@@ -106,6 +106,12 @@
     <Filter Include="Application\PauseMenu">
       <UniqueIdentifier>{b4266859-983c-4c23-8e9a-9e38136c7b61}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Application\EventData">
+      <UniqueIdentifier>{7e36b1ac-afc4-4eda-b231-93a52f331f9f}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Application\GameMusic">
+      <UniqueIdentifier>{7ce16ede-d359-462b-bc37-f072ab67e581}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />
@@ -240,6 +246,9 @@
     </ClCompile>
     <ClCompile Include="Source\Application\PauseMenu\PauseMenu.cpp">
       <Filter>Application\PauseMenu</Filter>
+    </ClCompile>
+    <ClCompile Include="Source\Application\GameMusic\GameMusic.cpp">
+      <Filter>Application\GameMusic</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -395,6 +404,12 @@
     </ClInclude>
     <ClInclude Include="Source\Application\PauseMenu\PauseMenu.h">
       <Filter>Application\PauseMenu</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\Application\GameMusic\GameMusic.h">
+      <Filter>Application\GameMusic</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\Application\EventData\PauseActionData.h">
+      <Filter>Application\EventData</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Application/Source/Application/BeatsManager/BeatManager.cpp
+++ b/Application/Source/Application/BeatsManager/BeatManager.cpp
@@ -31,7 +31,7 @@ void BeatManager::Initialize(float bpm, float offset, const std::string& soundPa
 void BeatManager::Update()
 {
     if (!playing_) return;
-    if (!musicVoiceInstance_ && !musicVoiceInstance_->IsPlaying())return;
+    if (!gameMusic_ || !gameMusic_->IsPlaying())return;
 
     // 新しい拍かチェック
     if (IsNewBeat() && soundEnabled_)
@@ -83,7 +83,7 @@ void BeatManager::Reset()
 
 float BeatManager::GetCurrentBeat() const
 {
-    float currentTime = musicVoiceInstance_->GetElapsedTime() - offset_;
+    float currentTime = gameMusic_->GetElapsedTime() - offset_;
     return currentTime / GetSecondsPerBeat();
 }
 

--- a/Application/Source/Application/BeatsManager/BeatManager.h
+++ b/Application/Source/Application/BeatsManager/BeatManager.h
@@ -3,6 +3,8 @@
 #include <System/Audio/VoiceInstance.h>
 #include <System/Time/Stopwatch.h>
 
+#include <Application/GameMusic/GameMusic.h>
+
 #include <string>
 #include <cstdint>
 #include <memory>
@@ -58,6 +60,7 @@ public:
 
     void SetMusicVoiceInstance(std::shared_ptr<VoiceInstance> voiceInstance) { musicVoiceInstance_ = voiceInstance; }
 
+    void SetGameMusic(const GameMusic* _gameMusic) { gameMusic_ = _gameMusic; }
 private:
     Stopwatch* stopwatch_;
     float bpm_ = 120.0f;       // 1分あたりの拍数
@@ -70,6 +73,8 @@ private:
     std::shared_ptr<VoiceInstance> voiceInstance_; // ボイスインスタンス
 
     std::shared_ptr<VoiceInstance> musicVoiceInstance_; // 音楽のボイスインスタンス
+
+    const GameMusic* gameMusic_; // 音楽の管理
 
     float volume_ = 0.5f;
     bool soundEnabled_ = true;

--- a/Application/Source/Application/Core/GameCore.cpp
+++ b/Application/Source/Application/Core/GameCore.cpp
@@ -73,13 +73,13 @@ void GameCore::Update(float  _deltaTime, const std::vector<InputDate>& _inputDat
         waitTimer_ += _deltaTime;
         elapsedTime = Lerp(-offset_, 0.0f, waitTimer_ / offset_);
     }
-    else if (auto voiceInstance = musicVoiceInstance_.lock())
+    else if (gamemusic_)
     {
         // 音楽の音声インスタンスが有効な場合、経過時間を取得
-        if (voiceInstance->IsPlaying())
+        if (gamemusic_->IsPlaying())
         {
             // 音楽が再生中の場合、経過時間を取得
-            elapsedTime = voiceInstance->GetElapsedTime();
+            elapsedTime = gamemusic_->GetElapsedTime();
         }
     }
     for (auto& lane : lanes_)
@@ -206,12 +206,11 @@ void GameCore::CreateBeatMapNotes()
     }
 }
 
-void GameCore::Restart(std::shared_ptr<VoiceInstance> _voiceInstance)
+void GameCore::Restart()
 {
     isWaitingForStart_ = true;
     waitTimer_ = 0.0f;
 
-    SetMusicVoiceInstance(_voiceInstance);
     CreateBeatMapNotes();
     judgeResult_->Initialize();
 

--- a/Application/Source/Application/Core/GameCore.h
+++ b/Application/Source/Application/Core/GameCore.h
@@ -9,6 +9,7 @@
 #include <Application/Input/InputData.h>
 #include <Application/Note/Judge/NoteJudge.h>
 #include <Application/Note/Judge/JudgeResult.h>
+#include <Application/GameMusic/GameMusic.h>
 
 // STL
 #include <functional>
@@ -58,6 +59,11 @@ public:
     /// <param name="_voiceInstance">音声インスタンスを</param>
     void SetMusicVoiceInstance(std::shared_ptr<VoiceInstance> _voiceInstance) { musicVoiceInstance_ = _voiceInstance; }
 
+    /// <summary>
+    /// GameMusicを設定する
+    /// </summary>
+    /// <param name="_gameMusic">GameMusicのインスタンス</param>
+    void SetGameMusic(const GameMusic* _gameMusic) { gamemusic_ = _gameMusic; }
 
     /// <summary>
     /// 開始
@@ -67,7 +73,7 @@ public:
     /// <summary>
     /// リスタート
     /// </summary>
-    void Restart(std::shared_ptr<VoiceInstance> _voiceInstance);
+    void Restart();
 
 
     /// <summary>
@@ -163,5 +169,7 @@ private:
 
 
     std::weak_ptr<VoiceInstance> musicVoiceInstance_; // 音楽の音声インスタンス 弱参照
+
+    const GameMusic* gamemusic_ = nullptr; // 音楽の管理
 
 };

--- a/Application/Source/Application/EventData/PauseActionData.h
+++ b/Application/Source/Application/EventData/PauseActionData.h
@@ -1,0 +1,22 @@
+#pragma once
+#include <Features/Event/EventData.h>
+
+enum class PauseActions
+{
+    None,
+    Open,
+    Close,
+
+    Resume,
+    Retry,
+    ToTitle,
+
+    Max
+};
+
+struct PauseActionData : EventData
+{
+    PauseActions pauseAction = PauseActions::None;
+
+    PauseActionData(PauseActions _action) : pauseAction(_action) {}
+};

--- a/Application/Source/Application/GameMusic/GameMusic.cpp
+++ b/Application/Source/Application/GameMusic/GameMusic.cpp
@@ -1,0 +1,101 @@
+#include "GameMusic.h"
+
+#include <System/Audio/AudioSystem.h>
+
+#include <Application/EventData/PauseActionData.h>
+
+GameMusic::GameMusic(const std::string& _musicFilePath)
+{
+    soundInstance_ = AudioSystem::GetInstance()->Load(_musicFilePath);
+}
+
+GameMusic::~GameMusic()
+{
+}
+
+void GameMusic::Initialize(float _rewindTime)
+{
+    voiceCallBack_ = std::make_unique<VoiceCallBack>();
+    voiceCallBack_->SetOnStreamEndCallback([this]() {MusicEnd(); }); // 音楽が終了したときのコールバックを設定
+
+    rewindTime_ = _rewindTime;
+    pausedAtTime_ = 0.0f;
+    isMusicPlaying_ = false;
+
+}
+
+float GameMusic::GetElapsedTime() const
+{
+    if (voiceInstance_)
+    {
+        return voiceInstance_->GetElapsedTime();
+    }
+    return 0.0f; // voiceInstanceがない場合は0を返す
+}
+
+void GameMusic::Play(float _volume)
+{
+    if (isMusicPlaying_)
+        return;
+
+    if (voiceInstance_)
+        voiceInstance_.reset();
+
+    voiceInstance_ = soundInstance_->Play(_volume, 0, false, true, voiceCallBack_.get());
+
+    isMusicPlaying_ = true;
+
+}
+
+void GameMusic::Resume()
+{
+    if (voiceInstance_ && !isMusicPlaying_)
+    {
+        voiceInstance_->Play();
+        isMusicPlaying_ = true;
+    }
+}
+
+void GameMusic::ResumeWithRewind(float _volume)
+{
+    if (voiceInstance_ && !isMusicPlaying_)
+    {
+        if (voiceInstance_)
+            voiceInstance_.reset();
+
+        float startTime = pausedAtTime_ - rewindTime_;
+        startTime = (std::max)(startTime, 0.0f);
+
+        voiceInstance_ = soundInstance_->Play(_volume, startTime, false, true, voiceCallBack_.get());
+        isMusicPlaying_ = true;
+    }
+}
+
+void GameMusic::Pause()
+{
+    if (voiceInstance_ && isMusicPlaying_)
+    {
+        pausedAtTime_ = voiceInstance_->GetElapsedTime(); // 現在の再生時間を記録
+
+        voiceInstance_->Pause();
+        isMusicPlaying_ = false;
+    }
+}
+
+void GameMusic::SetVolume(float _volume)
+{
+    if (voiceInstance_)
+    {
+        voiceInstance_->SetVolume(_volume);
+    }
+}
+
+float GameMusic::GetDuration() const
+{
+    if (soundInstance_)
+    {
+        return soundInstance_->GetDuration();
+    }
+
+    return 0.0f; // soundInstanceがない場合は0を返す
+}

--- a/Application/Source/Application/GameMusic/GameMusic.h
+++ b/Application/Source/Application/GameMusic/GameMusic.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <System/Audio/SoundInstance.h>
+
+class GameMusic // voiceInstanceのラッパー
+{
+public:
+
+    GameMusic(const std::string& _musicFilePath);
+    ~GameMusic();
+
+    void Initialize(float _rewindTime = 1.0f);
+
+    float GetElapsedTime() const;
+
+    void Play(float _volume);
+
+    void Resume();
+
+    void ResumeWithRewind(float _volume);
+
+    void Pause();
+
+    void SetVolume(float _volume);
+
+    bool IsPlaying() const { return isMusicPlaying_; }
+
+    bool IsMusicEnd() const { return isMusicEnd_; }
+
+    float GetDuration()const;
+private:
+
+    void MusicEnd() { isMusicEnd_ = true; };
+
+private:
+
+    std::shared_ptr<SoundInstance> soundInstance_;
+    std::shared_ptr<VoiceInstance> voiceInstance_;
+
+    std::unique_ptr<VoiceCallBack> voiceCallBack_;
+
+    bool isMusicPlaying_ = false; // 音楽が再生中かどうか
+    bool isMusicEnd_ = false; // 音楽が終了したかどうか
+    // 巻き戻し時間
+    float rewindTime_ = 1.0f;
+
+    // 曲を停止時点での再生経過時間
+    float pausedAtTime_ = 0.0f;
+};

--- a/Application/Source/Application/Input/GameInputManager.cpp
+++ b/Application/Source/Application/Input/GameInputManager.cpp
@@ -16,14 +16,14 @@ void GameInputManager::Initialize(Input* _input)
 
 void GameInputManager::Update()
 {
-    if (auto musicVoiceInstance = musicVoiceInstance_.lock())
+    if (gameMusic_)
     {
         inputData_.clear(); // 前回の入力データをクリア
 
         for (const auto& [keycode, laneIndex] : keyBindings_)
         {
             InputDate inputData;
-            inputData.elapsedTime = musicVoiceInstance->GetElapsedTime();
+            inputData.elapsedTime = gameMusic_->GetElapsedTime();
             inputData.laneIndex = laneIndex;
 
             if (input_->IsKeyTriggered(keycode))

--- a/Application/Source/Application/Input/GameInputManager.h
+++ b/Application/Source/Application/Input/GameInputManager.h
@@ -3,6 +3,7 @@
 #include <System/Input/Input.h>
 
 #include <Application/Input/InputData.h>
+#include <Application/GameMusic/GameMusic.h>
 
 #include <map>
 #include <cstdint>
@@ -55,6 +56,8 @@ public:
     /// </summary>
     /// <param name="_voiceInstance">音声インスタンスのポインタ </param>
     void SetMusicVoiceInstance(std::shared_ptr<VoiceInstance> _voiceInstance) { musicVoiceInstance_ = _voiceInstance; }
+
+    void SetGameMusic(const GameMusic* _gameMusic) { gameMusic_ = _gameMusic; }
 private:
 
     /// <summary>
@@ -70,4 +73,6 @@ private:
     std::map<int8_t, int32_t> keyBindings_; // キーのバインディング
 
     std::weak_ptr<VoiceInstance> musicVoiceInstance_; // 音楽の音声インスタンス
+
+    const GameMusic* gameMusic_ = nullptr; // ゲーム音楽のインスタンス
 };

--- a/Application/Source/Application/PauseMenu/PauseMenu.cpp
+++ b/Application/Source/Application/PauseMenu/PauseMenu.cpp
@@ -3,55 +3,46 @@
 #include <System/Input/Input.h>
 #include <Debug/ImGuiDebugManager.h>
 
+
 #include <Features/UI/UISprite.h>
 
 
 void PauseMenu::Initialize()
 {
+
     uiGroup_ = std::make_unique<UIGroup>();
     uiGroup_->Initialize();
 
     auto sprite = uiGroup_->CreateSprite("PauseMenu_back", L"Pause");
 
     auto resumeButton = uiGroup_->CreateButton("PauseMenu_ResumeButton", L"Resume");
-    resumeButton->SetCallBackOnClickEnd([this]() {
-        isActive_ = false; // ポーズメニューを閉じる
-        selectedButton_ = PauseMenuButton::Resume; // 選択されたボタンを更新
-        });
     resumeButton->SetParent(sprite);
+
     auto retryButton = uiGroup_->CreateButton("PauseMenu_RetryButton",L"Retry");
-    retryButton->SetCallBackOnClickEnd([this]() {
-        isActive_ = false; // ポーズメニューを閉じる
-        selectedButton_ = PauseMenuButton::Retry; // 選択されたボタンを更新
-        });
     retryButton->SetParent(sprite);
 
     auto toTitleButton = uiGroup_->CreateButton("PauseMenu_ToTitleButton", L"Title");
-    toTitleButton->SetCallBackOnClickEnd([this]() {
-        isActive_ = false; // ポーズメニューを閉じる
-        selectedButton_ = PauseMenuButton::ToTitile; // 選択されたボタンを更新
-        });
     toTitleButton->SetParent(sprite);
 
     UIGroup::LinkHorizontal(
         { resumeButton, retryButton, toTitleButton }
     );
 
-#ifdef _DEBUG
-    debugSprite_ = sprite;
+    sprite_= sprite;
 
-    debugButton_.push_back(resumeButton);
-    debugButton_.push_back(retryButton);
-    debugButton_.push_back(toTitleButton);
-
-#endif
-
+    buttons_["PauseMenu_ResumeButton"] = resumeButton;
+    buttons_["PauseMenu_RetryButton"] = retryButton;
+    buttons_["PauseMenu_ToTitleButton"] = toTitleButton;
 }
 
 void PauseMenu::Update()
 {
     if (Input::GetInstance()->IsKeyTriggered(DIK_ESCAPE))
+    {
         isActive_ = !isActive_;
+        actions_ = isActive_ ? PauseActions::Open : PauseActions::Close; // ポーズメニューの開閉をトグル
+
+    }
 
     if (!isActive_)
         return;
@@ -63,15 +54,14 @@ void PauseMenu::Update()
 
     if (ImGuiDebugManager::GetInstance()->Begin("pauseMenu"))
     {
-        std::string strings[3] = { "resume", "retry", "toTitle" };
         if (ImGui::CollapsingHeader("sprite"))
-            debugSprite_->ImGui();
+            sprite_->ImGui();
 
-        for (size_t i = 0; i < 3; i++)
+        for (auto& [key, button] : buttons_)
         {
-            if (ImGui::CollapsingHeader(strings[i].c_str()))
+            if (ImGui::CollapsingHeader(key.c_str()))
             {
-                debugButton_[i]->ImGui();
+                button->ImGui();
             }
         }
 
@@ -89,5 +79,63 @@ void PauseMenu::Draw()
         return;
 
     uiGroup_->Draw();
+}
 
+void PauseMenu::SetCallBacks(const std::function<void()>& _onResumeCallback, const std::function<void()>& _onRetryCallback, const std::function<void()>& _onToTitleCallback)
+{
+    SetOnResumeCallback(_onResumeCallback);
+    SetOnRetryCallback(_onRetryCallback);
+    SetOnToTitleCallback(_onToTitleCallback);
+}
+
+void PauseMenu::SetOnResumeCallback(const std::function<void()>& _callback)
+{
+    if (_callback)
+    {
+        onResumeCallback_ = _callback;
+
+        auto it = buttons_.find("PauseMenu_ResumeButton");
+        if (it != buttons_.end())
+        {
+            it->second->SetCallBackOnClickEnd([this]() {
+                isActive_ = false; // ポーズメニューを閉じる
+                actions_ = PauseActions::Resume; // 選択されたボタンを更新
+                onResumeCallback_(); // コールバックを呼び出す
+                });
+        }
+    }
+}
+
+void PauseMenu::SetOnRetryCallback(const std::function<void()>& _callback)
+{
+    if (_callback)
+    {
+        onRetryCallback_ = _callback;
+        auto it = buttons_.find("PauseMenu_RetryButton");
+        if (it != buttons_.end())
+        {
+            it->second->SetCallBackOnClickEnd([this]() {
+                isActive_ = false; // ポーズメニューを閉じる
+                actions_ = PauseActions::Retry; // 選択されたボタンを更新
+                onRetryCallback_(); // コールバックを呼び出す
+                });
+        }
+    }
+}
+
+void PauseMenu::SetOnToTitleCallback(const std::function<void()>& _callback)
+{
+    if (_callback)
+    {
+        onToTitleCallback_ = _callback;
+        auto it = buttons_.find("PauseMenu_ToTitleButton");
+        if (it != buttons_.end())
+        {
+            it->second->SetCallBackOnClickEnd([this]() {
+                isActive_ = false; // ポーズメニューを閉じる
+                actions_ = PauseActions::ToTitle; // 選択されたボタンを更新
+                onToTitleCallback_(); // コールバックを呼び出す
+                });
+        }
+    }
 }

--- a/Application/Source/Application/PauseMenu/PauseMenu.h
+++ b/Application/Source/Application/PauseMenu/PauseMenu.h
@@ -2,19 +2,11 @@
 
 #include <Features/UI/UIGroup.h>
 
+#include <Application/EventData/PauseActionData.h>
+
 #include <memory>
 
-enum class PauseMenuButton
-{
-    None,
-    Resume,
-    Retry,
-    ToTitile,
-
-    Max
-    // memo : titileは仮 セレクト実装するまで
-
-};
+class EventManager;
 
 class PauseMenu
 {
@@ -30,22 +22,31 @@ public:
     //
     bool IsActive() const { return isActive_; }
 
-    PauseMenuButton GetSelectedButton() const { return selectedButton_; }
+    PauseActions GetSelectedButton() const { return actions_; }
+
+    void SetCallBacks(const std::function<void()>& _onResumeCallback,
+                    const std::function<void()>& _onRetryCallback,
+                    const std::function<void()>& _onToTitleCallback);
+
+    void SetOnResumeCallback(const std::function<void()>& _callback);
+    void SetOnRetryCallback(const std::function<void()>& _callback)   ;
+    void SetOnToTitleCallback(const std::function<void()>& _callback) ;
+
 
 private:
 
     // 有効か否か
     bool isActive_ = false;
 
-    PauseMenuButton selectedButton_ = PauseMenuButton::None;
+    PauseActions actions_ = PauseActions::None;
 
     std::unique_ptr<UIGroup> uiGroup_ = nullptr;
 
-#ifdef _DEBUG
+    std::function<void()> onResumeCallback_ = nullptr; // レジュームボタンのコールバック
+    std::function<void()> onRetryCallback_ = nullptr;  // リトライボタンのコールバック
+    std::function<void()> onToTitleCallback_ = nullptr; // タイトルに戻るボタンのコールバック
 
-    std::vector<UIButton*> debugButton_;
-    UISprite* debugSprite_ = nullptr;
-
-#endif
+    std::map<std::string, UIButton*> buttons_;
+    UISprite* sprite_ = nullptr;
 
 };

--- a/Application/Source/Application/Scene/GameScene.cpp
+++ b/Application/Source/Application/Scene/GameScene.cpp
@@ -22,11 +22,6 @@
 
 GameScene::~GameScene()
 {
-    if (voiceInstance_)
-    {
-        voiceInstance_->Stop();
-        voiceInstance_.reset();
-    }
 }
 
 // TODO ; やりたいこと にゅうりょく精度アップ
@@ -136,6 +131,8 @@ void GameScene::Initialize(SceneData* _sceneData)
 
     isTransitionToResultScene_ = true;
 
+    isMusicPlaying_ = true;
+
     LayerSystem::CreateLayer("GameEnvironment", 0);
     LayerSystem::CreateLayer("GameCore", 1);
     LayerSystem::CreateLayer("FeedbackEffect", 2, PSOFlags::BlendMode::Add);
@@ -168,7 +165,13 @@ void GameScene::Update()
     if(input_->IsKeyTriggered(DIK_F8))
         isTransitionToResultScene_ = !isTransitionToResultScene_; // F8キーで結果シーンへの遷移を切り替え
     if (input_->IsKeyTriggered(DIK_F7))
+    {
         noteUpdateEnabled_ = !noteUpdateEnabled_;
+        if(noteUpdateEnabled_)
+            gameMusic_->Resume(); // ノート更新が有効なら音楽を再生
+        else
+            gameMusic_->Pause(); // ノート更新が無効なら音楽を一時停止
+    }
 
     depthBasedOutLineData_.ImGui();
 
@@ -178,18 +181,7 @@ void GameScene::Update()
 
     if (input_->IsKeyPressed(DIK_LCONTROL) && input_->IsKeyTriggered(DIK_R))
     {
-        voiceInstance_->Stop();
-        voiceInstance_.reset();
-
-        voiceInstance_ = soundInstance_->GenerateVoiceInstance(0.3f, 0.0f); // ボリュームとオフセットを設定して再生
-
-        beatManager_->Reset();
-
-        gameCore_->Restart(voiceInstance_);
-        gameInputManager_->SetMusicVoiceInstance(voiceInstance_);
-        beatManager_->SetMusicVoiceInstance(voiceInstance_);
-
-        isWatingForStart_ = true;
+        Retry();
     }
 
     depthBasedOutLineData_.edgeColor.x = std::sin(static_cast<float>((Time::GetCurrentTime)())) * 0.5f + 0.5f;
@@ -206,8 +198,7 @@ void GameScene::Update()
     }
     else
     {
-        if(voiceInstance_)
-            voiceInstance_->Stop();
+        gameMusic_->Pause();
     }
     feedbackEffect_->Update(deltaTime, gameInputManager_->GetInputData());
     gameEnvironment_->Update(deltaTime);
@@ -232,7 +223,8 @@ void GameScene::Update()
 
     if (IsMusicEnd())
     {
-        if(isTransitionToResultScene_)
+
+        if (isTransitionToResultScene_)
         {
             auto data = std::make_unique<GameToResultData>();
             data->resultData.musicTitle = beatMapLoader_->GetLoadedBeatMapData().title; // 譜面のタイトルを取得
@@ -361,19 +353,26 @@ bool GameScene::IsComplateLoadBeatMap()
         beatManager_->SetBPM(beatMapLoader_->GetLoadedBeatMapData().bpm);
         beatManager_->SetOffset(beatMapLoader_->GetLoadedBeatMapData().offset);
         std::string audioFilePath = beatMapLoader_->GetLoadedBeatMapData().audioFilePath;
-        soundInstance_ = AudioSystem::GetInstance()->Load(audioFilePath);
+
+        gameMusic_ = std::make_unique<GameMusic>(audioFilePath); // 音楽の管理を初期化
+        gameMusic_->Initialize();
 
         gameEnvironment_->SetBPM(beatMapLoader_->GetLoadedBeatMapData().bpm);
 
         // ロード完了
         Debug::Log("BeatMap Loaded Successfully\n");
-        if(soundInstance_)
-            voiceInstance_ = soundInstance_->GenerateVoiceInstance(0.3f, 0.0f);
-        if (voiceInstance_)
+
+        if (gameMusic_)
         {
-            beatManager_->SetMusicVoiceInstance(voiceInstance_);
-            gameCore_->SetMusicVoiceInstance(voiceInstance_);
-            gameInputManager_->SetMusicVoiceInstance(voiceInstance_); // 入力管理に音声インスタンスを設定
+            beatManager_->SetGameMusic(gameMusic_.get());
+            gameCore_->SetGameMusic(gameMusic_.get());
+            gameInputManager_->SetGameMusic(gameMusic_.get()); // 入力管理に音声インスタンスを設定
+
+            pauseMenu_->SetCallBacks(
+                [this]() { gameMusic_->ResumeWithRewind(0.3f); }, // 一時停止コールバック
+                [this]() { Retry(); }, // リトライコールバック
+                [this]() { ToTitle(); } // タイトルに戻るコールバック
+            );
         }
         else
         {
@@ -406,27 +405,30 @@ void GameScene::UpdateGameStartOffset()
         beatManager_->Start();
         gameCore_->Start();
 
-        if (voiceInstance_)
-            voiceInstance_->Play();
+        if (gameMusic_)
+            gameMusic_->Play(0.3f);
     }
 }
 
 bool GameScene::IsMusicEnd() const
 {
-    if(!isBeatMapLoaded_)
-        return false;
-
-    if (!voiceInstance_)
-        return false;
-
-    if (!voiceInstance_->IsPlaying())
+    if (gameMusic_ && gameMusic_->IsMusicEnd())
         return true;
 
-    voiceInstance_->GetElapsedTime();
-    soundInstance_->GetDuration();
-
-
     return false;
+}
+
+void GameScene::Retry()
+{
+    beatManager_->Reset();
+    gameCore_->Restart();
+    gameMusic_->Pause();
+    isWatingForStart_ = true;
+}
+
+void GameScene::ToTitle()
+{
+    SceneManager::ReserveScene("TitleScene", nullptr);
 }
 
 
@@ -447,7 +449,7 @@ void GameScene::ImGui()
         ImGui::Text("combo: %d", gameCore_->GetCombo());
         ImGui::Text("maxCombo: %d", gameCore_->GetMaxCombo());
 
-        float time = voiceInstance_->GetElapsedTime();
+        float time = gameMusic_->GetElapsedTime();
         ImGui::Text("Elapsed Time: %.2f", time);
 
 
@@ -459,7 +461,7 @@ void GameScene::ImGui()
 
         if (ImGui::Button("play##music"))
         {
-            voiceInstance_->Play();
+            gameMusic_->Play(0.3f);
         }
         static float bpm = 120;
         ImGui::DragFloat("BPM", &bpm, 0.1f);
@@ -471,26 +473,24 @@ void GameScene::ImGui()
 
         static float volume = 0.2f;
         if (ImGui::DragFloat("music Vol", &volume, 0.01f))
-            voiceInstance_->SetVolume(volume);
+            gameMusic_->SetVolume(volume);
 
         static float offset = 0.6f;
         ImGui::DragFloat("offset", &offset, 0.001f);
 
         if (input_->IsKeyTriggered(DIK_R))
         {
-            voiceInstance_->Stop();
-            voiceInstance_.reset();
-            voiceInstance_ = soundInstance_->Play(volume); // ボリュームとオフセットを設定して再生
-            gameCore_->Restart(voiceInstance_); // ゲームコアに音声インスタンスを設定
-            gameInputManager_->SetMusicVoiceInstance(voiceInstance_);
+            gameMusic_->Pause();
+            gameMusic_->Play(0.3f);
+            gameCore_->Restart(); // ゲームコアに音声インスタンスを設定
             beatManager_->Reset();
         }
 
 
         ImGui::Separator();
-        ImGui::Text("Music Duration : %.2fsec", soundInstance_->GetDuration());
-        if (voiceInstance_)
-            ImGui::Text("Music elapse   : %.2fsec", voiceInstance_->GetElapsedTime());
+        ImGui::Text("Music Duration : %.2fsec", gameMusic_->GetDuration());
+        if (gameMusic_)
+            ImGui::Text("Music elapse   : %.2fsec", gameMusic_->GetElapsedTime());
 
         static float noteSpeed = 30.0f;
         if (ImGui::DragFloat("Note Speed", &noteSpeed, 0.1f, 0.1f, 100.0f))

--- a/Application/Source/Application/Scene/GameScene.h
+++ b/Application/Source/Application/Scene/GameScene.h
@@ -21,6 +21,7 @@
 #include <Application/Input/GameInputManager.h>
 #include <Application/FeedBack/FeedbackEffect.h>
 #include <Application/GameEnvironment/GameEnvironment.h>
+#include <Application/GameMusic/GameMusic.h>
 #include <Application/GameUI/GameUI.h>
 
 #include <Application/BeatsManager/BeatManager.h>
@@ -64,6 +65,9 @@ private:
     // 曲の再生が終わったか
     bool IsMusicEnd() const;
 
+    void Retry();
+
+    void ToTitle();
 private:
 
     // シーン関連
@@ -100,8 +104,9 @@ private:
     float gameStartOffset_ = 2.0f;
     float waitTimer_ = 0.0f;
 
-    std::shared_ptr<SoundInstance> soundInstance_ = nullptr;
-    std::shared_ptr<VoiceInstance> voiceInstance_ = nullptr;
+    bool isMusicPlaying_ = false; // 音楽が再生中かどうか
+
+    std::unique_ptr<GameMusic> gameMusic_ = nullptr; // 音楽の管理
 
 
     GameMode gameMode_ = GameMode::Normal;

--- a/Application/imgui.ini
+++ b/Application/imgui.ini
@@ -1,6 +1,6 @@
 [Window][WindowOverViewport_11111111]
 Pos=0,19
-Size=46,32
+Size=32,32
 Collapsed=0
 
 [Window][Debug##Default]
@@ -52,7 +52,7 @@ Collapsed=0
 DockId=0x00000005,0
 
 [Window][JudgeResult]
-Pos=18,30
+Pos=414,71
 Size=120,141
 Collapsed=0
 


### PR DESCRIPTION
ゲーム楽曲を管理するGameMusicクラスをラッパーとして作成
core input等でvoiceを使用していたのをこれに置換
ポーズメニュークラスにコールバックを取得する関数を作成し，ボタンのコールバックを設定できるよう実装

- `GameMusic.cpp`と`GameMusic.h`を追加し、音楽管理機能を実装
- `BeatManager`に`gameMusic_`メンバーを追加し、音楽の再生・停止処理を更新
- `GameCore`に`gamemusic_`メンバーを追加し、音楽の再生・更新処理を変更
- `GameInputManager`で音楽の再生時間取得処理を`gameMusic_`に変更
- `PauseMenu`にコールバック機能を追加し、ボタンの選択状態を管理する`actions_`メンバーを導入
- `GameScene`で音楽管理を`GameMusic`クラスを通じて行うように変更
- `PauseActionData`構造体を追加し、ポーズメニューのアクションを管理する列挙型を定義
- `RhythmProject.vcxproj`と`RhythmProject.vcxproj.filters`にフィルターを追加し、プロジェクト構造を整理
- `imgui.ini`ファイルのウィンドウ設定を変更
- サブプロジェクトのコミットIDを更新