### PR TITLE
ノート判定処理のリファクタリングと長押し判定の実装

### DIFF
--- a/Application/Resources/Data/Game/BeatMap/holdTest.json
+++ b/Application/Resources/Data/Game/BeatMap/holdTest.json
@@ -1,0 +1,28 @@
+{
+    "artist": "unknown",
+    "audioFilePath": "C:\\class\\RhythmProject\\Application\\Resources\\Sounds\\Music\\Luminous_memory.wav",
+    "bpm": 100.0,
+    "difficultyLevel": 0,
+    "notes": [
+        {
+            "holdDuration": 1.8000000715255737,
+            "laneIndex": 3,
+            "noteType": "hold",
+            "targetTime": 1.2000000476837158
+        },
+        {
+            "holdDuration": 1.8000000715255737,
+            "laneIndex": 2,
+            "noteType": "hold",
+            "targetTime": 4.200000286102295
+        },
+        {
+            "holdDuration": 2.4000000953674316,
+            "laneIndex": 1,
+            "noteType": "hold",
+            "targetTime": 6.600000381469727
+        }
+    ],
+    "offset": 0.0,
+    "title": "None"
+}

--- a/Application/Source/Application/BeatMapEditor/BeatMapEditor.cpp
+++ b/Application/Source/Application/BeatMapEditor/BeatMapEditor.cpp
@@ -797,7 +797,7 @@ void BeatMapEditor::InitWithBeatMapData(const BeatMapData& _beatMapData)
 {
     Reset(); // エディターの状態をリセット
 
-    if (_beatMapData.title == "None")
+    if (_beatMapData.notes.empty())
         return;
 
     currentBeatMapData_ = _beatMapData; // BeatMapDataを設定

--- a/Application/Source/Application/Core/GameCore.cpp
+++ b/Application/Source/Application/Core/GameCore.cpp
@@ -4,9 +4,6 @@
 #include <Math/MyLib.h>
 #include <Debug/Debug.h>
 
-// TODO : 判定ラインパーフェクトでない
-// 判定ラインでパーフェクトにならない 一本目の黄色ラインがそうなっている なぁぜ
-
 GameCore::GameCore(int32_t _laneCount) :
     laneCount_(_laneCount),
     isWaitingForStart_(true),
@@ -128,44 +125,119 @@ void GameCore::JudgeNotes(const std::vector<InputDate>& _inputData)
             continue;
 
         JudgeType result = JudgeType::None; // 初期化
-        if (note->GetNoteType() == NoteType::Normal||
-            note->GetNoteType() == NoteType::Hold)
+        NoteType noteType= note->GetNoteType();
+        switch (noteType)
         {
-            if(inputdata.state == KeyState::trigger)
-                result = noteJudge_->ProcessNoteJudge(note, inputdata.elapsedTime);
-        }
-        else if (note->GetNoteType() == NoteType::HoldEnd)
-        {
-            if (inputdata.state == KeyState::Released)
-            {
-                result = noteJudge_->ProcessNoteJudge(note, inputdata.elapsedTime);
-            }
+        case NoteType::Normal:
+            result = ProcessNormalNote(note, inputdata);
+            break;
+        case NoteType::Hold:
+            result = ProcessHoldNote(note, inputdata);
+            break;
+        case NoteType::HoldEnd:
+            result = ProcessHoldEndNote(note, inputdata);
+            break;
+        default:
+            break;
         }
 
         if (result == JudgeType::None)
             continue; // 判定なしの場合はスキップ
 
-        judgeResult_->AddJudge(result);
-        note->Judge();
+        RecordJudgeResult(result, note); // 判定結果を記録
 
         if (onJudgeCallback_)
             onJudgeCallback_(laneIndex, result); // 判定時のコールバックを呼び出す
 
-        if (result == JudgeType::Perfect ||
-            result == JudgeType::Good)
+        UpdateCombo(result);
+    }
+}
+
+JudgeType GameCore::ProcessNormalNote(Note* _note, const InputDate& _inputData)
+{
+    // 押した瞬間だけ判定
+    if (_inputData.state == KeyState::trigger)
+    {
+        return noteJudge_->ProcessNoteJudge(_note, _inputData.elapsedTime);
+    }
+
+    return JudgeType::None;
+}
+
+JudgeType GameCore::ProcessHoldNote(Note* _note, const InputDate& _inputData)
+{
+    // 押した瞬間だけ判定
+    if (_inputData.state == KeyState::trigger)
+    {
+        JudgeType result = noteJudge_->ProcessNoteJudge(_note, _inputData.elapsedTime);
+
+        if (result != JudgeType::None && result != JudgeType::Miss)
         {
-            ++combo_; // コンボを増やす
-            maxCombo_ = (std::max)(maxCombo_, combo_); // 最大コンボを更新
+            holdState_.StartHold(_inputData.laneIndex); // ホールド状態を開始
+            Debug::Log("Hold Enable\n");
         }
-        else
+
+        return result;
+    }
+
+    return JudgeType::None;
+}
+
+JudgeType GameCore::ProcessHoldEndNote(Note* _note, const InputDate& _inputData)
+{
+    if (_inputData.state == KeyState::trigger)
+    {
+        holdState_.StartHold(_inputData.laneIndex); // ホールド状態を開始
+    }
+    else if(holdState_.IsHoldingLane(_inputData.laneIndex))
+    {
+        Debug::Log("Hold State is holding lane: " + std::to_string(_inputData.laneIndex) + "\n");
+
+        if (_inputData.state == KeyState::Released)
         {
-            combo_ = 0; // コンボが途切れたらリセット
-            if (onMissCallback_)
+            JudgeType result = noteJudge_->ProcessNoteJudge(_note, _inputData.elapsedTime);
+
+            holdState_.EndHold(); // ホールド状態を終了
+            // noneてことはブリッジ内なので
+            if (result == JudgeType::None)
             {
-                onMissCallback_(); // ミス時のコールバックを呼び出す
+                // コンボを途切れさせる
+                // 判定は反映させない
+                UpdateCombo(result);
             }
+
+            return result;
         }
     }
+
+    return JudgeType::None;
+}
+
+void GameCore::UpdateCombo(JudgeType _result)
+{
+    if (_result == JudgeType::Perfect ||
+        _result == JudgeType::Good)
+    {
+        ++combo_; // コンボを増やす
+        maxCombo_ = (std::max)(maxCombo_, combo_); // 最大コンボを更新
+    }
+    else
+    {
+        combo_ = 0; // コンボが途切れたらリセット
+        if (onMissCallback_)
+        {
+            onMissCallback_(); // ミス時のコールバックを呼び出す
+        }
+    }
+}
+
+void GameCore::RecordJudgeResult(JudgeType _result, Note* _note)
+{
+    if (_result == JudgeType::None)
+        return;
+
+    judgeResult_->AddJudge(_result);
+    _note->Judge();
 }
 
 void GameCore::ParseBeatMapData(const BeatMapData& _beatMapData)

--- a/Application/Source/Application/Core/GameCore.h
+++ b/Application/Source/Application/Core/GameCore.h
@@ -122,6 +122,16 @@ private:
 
     void JudgeNotes(const std::vector<InputDate>& _inputData);
 
+    JudgeType ProcessNormalNote(Note* _note, const InputDate& _inputData);
+
+    JudgeType ProcessHoldNote(Note* _note, const InputDate& _inputData);
+
+    JudgeType ProcessHoldEndNote(Note* _note, const InputDate& _inputData);
+
+    void UpdateCombo(JudgeType _result);
+
+    void RecordJudgeResult(JudgeType _result, Note* _note);
+
     /// <summary>
     /// ノーツを生成する
     /// </summary>
@@ -131,8 +141,30 @@ private:
     void CreateBeatMapNotes();
 
 private:
+    struct HoldState
+    {
+        bool isHolding = false;
+        int32_t laneIndex = -1;
+
+        void StartHold(int32_t lane) {
+            isHolding = true;
+            laneIndex = lane;
+        }
+
+        void EndHold() {
+            isHolding = false;
+            laneIndex = -1;
+        }
+
+        bool IsHoldingLane(int32_t lane) const {
+            return isHolding && laneIndex == lane;
+        }
+    };
+
+private:
 
     // note
+
     // lane
     float noteSpeed_ = 30.0f; // ノーツの移動速度
     int32_t laneCount_ = 4; // レーンの数
@@ -166,6 +198,10 @@ private:
     float offset_ = 2.0f; // ゲーム開始オフセット時間
     float waitTimer_ = 0.0f; // 開始前オフセット待機タイマー
     bool isWaitingForStart_ = true; // 開始前オフセット待機中かどうか
+
+
+    // ホールド中
+    HoldState holdState_ = {};
 
 
     std::weak_ptr<VoiceInstance> musicVoiceInstance_; // 音楽の音声インスタンス 弱参照

--- a/Application/imgui.ini
+++ b/Application/imgui.ini
@@ -52,7 +52,7 @@ Collapsed=0
 DockId=0x00000005,0
 
 [Window][JudgeResult]
-Pos=414,71
+Pos=323,42
 Size=120,141
 Collapsed=0
 
@@ -78,7 +78,7 @@ Collapsed=0
 
 [Window][Save Confirmation]
 Pos=360,250
-Size=570,144
+Size=591,144
 Collapsed=0
 
 [Window][Dear ImGui Demo]


### PR DESCRIPTION
- `BeatMapEditor.cpp`の`InitWithBeatMapData`関数で、空のノートデータに対する早期リターン処理を追加
- `GameCore.cpp`の`JudgeNotes`関数をリファクタリングし、ノートの種類に応じた処理を分割
- 新たに`ProcessNormalNote`、`ProcessHoldNote`、`ProcessHoldEndNote`、`RecordJudgeResult`メソッドを追加
- `GameCore.h`にホールド状態を管理する`HoldState`構造体を追加
- `imgui.ini`でウィンドウの位置とサイズを調整
- `holdTest.json`に新しい譜面データを追加し、ホールドノートの情報を含む