### PR TITLE
音楽遅延とオフセットの設定を改善

### DIFF
--- a/Application/Resources/Data/Setting/setting.json
+++ b/Application/Resources/Data/Setting/setting.json
@@ -1,7 +1,7 @@
 {
-    "audioLatencyMs": 35.5,
+    "audioLatencyMs": -45.0,
     "effectVolume": 1.0,
     "masterVolume": 0.41999998688697815,
     "musicVolume": 1.0,
-    "noteSpeed": 5.0
+    "noteSpeed": 50.0
 }

--- a/Application/Source/Application/Core/GameCore.cpp
+++ b/Application/Source/Application/Core/GameCore.cpp
@@ -19,10 +19,14 @@ GameCore::~GameCore()
 {
 }
 
-void GameCore::Initialize(float _noteSpeed, float _offset)
+void GameCore::Initialize(float _noteSpeed, float _musicLaytencyMs, float _beginOffset)
 {
     noteSpeed_ = _noteSpeed;
-    offset_ = _offset;
+    beginOffset_ = _beginOffset;
+    musicLatencyMs_ = _musicLaytencyMs;
+    waitTimer_ = 0.0f;
+    isWaitingForStart_ = true;
+
 
     // レーンの初期化
     lanes_.resize(laneCount_);
@@ -68,7 +72,7 @@ void GameCore::Update(float  _deltaTime, const std::vector<InputDate>& _inputDat
     if (isWaitingForStart_)
     {
         waitTimer_ += _deltaTime;
-        elapsedTime = Lerp(-offset_, 0.0f, waitTimer_ / offset_);
+        elapsedTime = Lerp(-beginOffset_, 0.0f, waitTimer_ / beginOffset_);
     }
     else if (gamemusic_)
     {
@@ -81,7 +85,7 @@ void GameCore::Update(float  _deltaTime, const std::vector<InputDate>& _inputDat
     }
     for (auto& lane : lanes_)
     {
-        lane->Update(elapsedTime, noteSpeed_);
+        lane->Update(elapsedTime + musicLatencyMs_ / 1000.0f, noteSpeed_);
     }
 }
 
@@ -158,7 +162,7 @@ JudgeType GameCore::ProcessNormalNote(Note* _note, const InputDate& _inputData)
     // 押した瞬間だけ判定
     if (_inputData.state == KeyState::trigger)
     {
-        return noteJudge_->ProcessNoteJudge(_note, _inputData.elapsedTime);
+        return noteJudge_->ProcessNoteJudge(_note, _inputData.elapsedTime + musicLatencyMs_ / 1000.0f);
     }
 
     return JudgeType::None;
@@ -169,7 +173,7 @@ JudgeType GameCore::ProcessHoldNote(Note* _note, const InputDate& _inputData)
     // 押した瞬間だけ判定
     if (_inputData.state == KeyState::trigger)
     {
-        JudgeType result = noteJudge_->ProcessNoteJudge(_note, _inputData.elapsedTime);
+        JudgeType result = noteJudge_->ProcessNoteJudge(_note, _inputData.elapsedTime + musicLatencyMs_ / 1000.0f);
 
         if (result != JudgeType::None && result != JudgeType::Miss)
         {
@@ -198,7 +202,7 @@ JudgeType GameCore::ProcessHoldEndNote(Note* _note, const InputDate& _inputData)
 
         if (_inputData.state == KeyState::Released)
         {
-            JudgeType result = noteJudge_->ProcessNoteJudge(_note, _inputData.elapsedTime);
+            JudgeType result = noteJudge_->ProcessNoteJudge(_note, _inputData.elapsedTime + musicLatencyMs_ / 1000.0f);
 
             holdState_.EndHold(); // ホールド状態を終了
             // noneてことはブリッジ内なので
@@ -277,7 +281,7 @@ void GameCore::CreateBeatMapNotes()
 {
     for (int32_t index = 0; index < notesPerLane_.size(); ++index)
     {
-        lanes_[index]->Initialize(notesPerLane_[index], index, 0.0f, noteSpeed_, offset_);// TODO 仮の値を使用している 判定ラインの座標
+        lanes_[index]->Initialize(notesPerLane_[index], index, 0.0f, noteSpeed_, beginOffset_);// TODO 仮の値を使用している 判定ラインの座標
     }
 }
 

--- a/Application/Source/Application/Core/GameCore.h
+++ b/Application/Source/Application/Core/GameCore.h
@@ -32,7 +32,7 @@ public:
     /// <summary>
     /// 初期化処理
     /// </summary>
-    void Initialize(float _noteSpeed, float _offset = 2.0f);
+    void Initialize(float _noteSpeed, float _musicLaytencyMs = 0.0f, float _beginOffset = 2.0f);
 
     /// <summary>
     /// 更新処理
@@ -100,6 +100,12 @@ public:
     /// </summary>
     /// <param name="_speed">ノーツの移動速度</param>
     void SetNoteSpeed(float _speed) { noteSpeed_ = _speed; noteJudge_->SetSpeed(noteSpeed_); }
+
+    /// <summary>
+    /// 音楽の遅延を設定する
+    /// </summary>
+    /// <param name="_latencyMs">遅延時間（ミリ秒）</param>
+    void SetMusicLatency(float _latencyMs) { musicLatencyMs_ = _latencyMs; }
 
     /// <summary>
     /// 最大コンボ数を取得する
@@ -204,9 +210,11 @@ private:
     float noteDeletePosition_ = -10.0f; // ノーツを削除する位置
 
     /// 開始前オフセット関連
-    float offset_ = 2.0f; // ゲーム開始オフセット時間
+    float beginOffset_ = 2.0f; // ゲーム開始オフセット時間
     float waitTimer_ = 0.0f; // 開始前オフセット待機タイマー
     bool isWaitingForStart_ = true; // 開始前オフセット待機中かどうか
+
+    float musicLatencyMs_ = 0.0f; // 音楽の遅延
 
 
     // ホールド中

--- a/Application/Source/Application/Scene/GameScene.cpp
+++ b/Application/Source/Application/Scene/GameScene.cpp
@@ -108,7 +108,10 @@ void GameScene::Initialize(SceneData* _sceneData)
     pauseMenu_->Initialize();
 
     settingMenu_ = std::make_unique<SettingMenu>();
-    settingMenu_->Initialize([&](float _noteSpeed) { gameCore_->SetNoteSpeed(_noteSpeed); });
+    settingMenu_->Initialize(
+        [&](float _noteSpeed) { gameCore_->SetNoteSpeed(_noteSpeed); },
+        [&](float _audioLatency) { gameCore_->SetMusicLatency(_audioLatency); }
+    );
 
     pauseMenu_->SetSeetingMenu(settingMenu_.get()); // ポーズメニューに設定メニューをセット
 

--- a/Application/Source/Application/Setting/SettingMenu.cpp
+++ b/Application/Source/Application/Setting/SettingMenu.cpp
@@ -40,7 +40,7 @@ void SettingMenu::Initialize(std::function<void(float)> _speedSetFunc, std::func
     auto audioLatencySlider = uiGroup_->CreateSlider("AudioLatencySlider", L"音声遅延");
     audioLatencySlider->SetPos({ 100, 200 });
     audioLatencySlider->SetSize({ 200, 20 });
-    audioLatencySlider->SetRange(0.0f, 100.0f);
+    audioLatencySlider->SetRange(-100.0f, 100.0f);
     audioLatencySlider->SetValue(Setting::current_.audioLatencyMs);
     audioLatencySlider->SetOnValueChanged([&](float value) {
         Setting::current_.audioLatencyMs = value; // 音声遅延を設定に反映


### PR DESCRIPTION
- `GameCore.cpp` の `Initialize` メソッドを変更し、`_offset` を `_musicLaytencyMs` と `_beginOffset` に置き換え
- `GameCore::Update` メソッドで `elapsedTime` の計算に `beginOffset` を使用
- `GameCore::JudgeNotes` と `GameCore::ProcessHoldNote` メソッドで音楽の遅延を考慮
- `GameCore::CreateBeatMapNotes` メソッドで `beginOffset_` を使用
- `GameCore.h` に `SetMusicLatency` メソッドと `beginOffset_` メンバーを追加
- `GameScene.cpp` で `SettingMenu` の初期化時に音楽の遅延設定コールバックを追加
- `SettingMenu.cpp` で音声遅延スライダーの範囲を -100.0 から 100.0 に変更