### PR TITLE
シーン遷移の管理を改善

### DIFF
--- a/Application/Resources/Data/SceneTransHex.json
+++ b/Application/Resources/Data/SceneTransHex.json
@@ -1,0 +1,10 @@
+{
+    "SceneTransHex": {
+        "animationDuration": 0.10000000149011612,
+        "duration": 1.0,
+        "hexagonSize": 100.0,
+        "phaseCount": 5,
+        "phaseDelay": 0.10000000149011612,
+        "spacing": 0.0
+    }
+}

--- a/Application/Source/Application/Scene/GameScene.cpp
+++ b/Application/Source/Application/Scene/GameScene.cpp
@@ -131,6 +131,7 @@ void GameScene::Initialize(SceneData* sceneData)
     Debug::Log(std::format("GameEnvironment Load Time: {} ms\n", std::chrono::duration_cast<std::chrono::milliseconds>(end - begin).count()));
     Load(beforeScene, beatMapFilePath, editorBeatMapData);
 
+    hasReservedTransition_ = false;
 }
 
 void GameScene::Update()
@@ -220,7 +221,7 @@ void GameScene::Update()
     {
         gameCompleteEffect_->Update(deltaTime);
 
-        if (isTransitionToResultScene_ && gameCompleteEffect_->IsEffectComplete())
+        if (isTransitionToResultScene_ && !hasReservedTransition_ && gameCompleteEffect_->IsEffectComplete())
         {
             auto data = std::make_unique<GameToResultData>();
             data->resultData.musicTitle = beatMapLoader_->GetLoadedBeatMapData().title; // 譜面のタイトルを取得
@@ -231,6 +232,7 @@ void GameScene::Update()
 
             UINavigationManager::GetInstance()->ClearFocus();
             SceneManager::ReserveScene("ResultScene", std::move(data)); // 結果シーンにデータを渡す
+            hasReservedTransition_ = true;
         }
     }
 

--- a/Application/Source/Application/Scene/GameScene.h
+++ b/Application/Source/Application/Scene/GameScene.h
@@ -149,6 +149,7 @@ private:
 
     std::unique_ptr<GameMusic> gameMusic_ = nullptr; // 音楽の管理
 
+    bool hasReservedTransition_ = false; // 結果シーンへの遷移を予約したかどうか
 
     GameMode gameMode_ = GameMode::Normal;
 


### PR DESCRIPTION
- `GameScene.cpp`の`Initialize`メソッドで`hasReservedTransition_`を初期化し、遷移状態を管理。
- `Update`メソッドの条件を変更し、重複遷移を防止。
- `GameScene.h`に`hasReservedTransition_`を追加。
- `Engine`のサブプロジェクトのコミットIDを更新。