### PR TITLE
ポーズの正常動作

### DIFF
--- a/Application/Source/Application/Core/GameCore.cpp
+++ b/Application/Source/Application/Core/GameCore.cpp
@@ -102,12 +102,14 @@ void GameCore::Update(float deltaTime,
 #endif // _DEBUG
 
     float elapsedTime = 0.0f;
-    if (isWaitingForStart_)
-    { // 開始前オフセット待機中
-        waitTimer_ += deltaTime;
-        elapsedTime = Lerp(-beginOffset_, 0.0f, waitTimer_ / beginOffset_);
-    }
-    else if (gamemusic_)
+    deltaTime;
+    //if (isWaitingForStart_)
+    //{ // 開始前オフセット待機中
+    //    waitTimer_ += deltaTime;
+    //    elapsedTime = Lerp(-beginOffset_, 0.0f, waitTimer_ / beginOffset_);
+    //}
+    //else 
+    if (gamemusic_)
     {
         // 音楽の音声インスタンスが有効な場合、経過時間を取得
         if (gamemusic_->IsPlaying())

--- a/Application/Source/Application/Lane/Lane.cpp
+++ b/Application/Source/Application/Lane/Lane.cpp
@@ -21,7 +21,7 @@ void Lane::Initialize(const std::list<NoteData>& noteDataList, int32_t laneIndex
 
     startPosition_ = endPosition_;
     startPosition_.z += laneLength_;
-
+    isHolding_ = false;
 
     CreateLaneModel();
 

--- a/Application/Source/Application/Scene/GameScene.cpp
+++ b/Application/Source/Application/Scene/GameScene.cpp
@@ -619,7 +619,11 @@ void GameScene::UpdatePlaying(float deltaTime)
     }
 
     pauseMenu_->Update();
-    settingMenu_->Update();
+    if (pauseMenu_->IsActive())
+    {
+        currentState_ = SceneState::Paused;
+        return;
+    }
 
     gameMusic_->Update(deltaTime);
 

--- a/Application/Source/Application/Scene/GameScene.h
+++ b/Application/Source/Application/Scene/GameScene.h
@@ -166,7 +166,7 @@ private:
     bool isBeatMapLoaded_ = false;
 
     bool isWatingForStart_ = false;
-    float gameStartOffset_ = 3.0f;
+    float gameStartOffset_ = 5.0f;
     float waitTimer_ = 0.0f;
 
     bool isMusicPlaying_ = false; // 音楽が再生中かどうか

--- a/Application/imgui.ini
+++ b/Application/imgui.ini
@@ -1,6 +1,6 @@
 [Window][WindowOverViewport_11111111]
 Pos=0,24
-Size=1280,696
+Size=46,32
 Collapsed=0
 
 [Window][TitleUI Animation]
@@ -146,5 +146,5 @@ DockNode      ID=0x00000001 Pos=858,-29 Size=396,626 Split=X Selected=0x933ECD57
     DockNode  ID=0x00000004 Parent=0x00000002 SizeRef=198,177 Selected=0xF07A5C35
     DockNode  ID=0x00000005 Parent=0x00000002 SizeRef=198,447 Selected=0xA9743CEC
   DockNode    ID=0x00000003 Parent=0x00000001 SizeRef=125,626 Selected=0x933ECD57
-DockSpace     ID=0x08BD597D Window=0x1BBC0F80 Pos=0,24 Size=1280,696 CentralNode=1
+DockSpace     ID=0x08BD597D Window=0x1BBC0F80 Pos=0,24 Size=32,32 CentralNode=1
 


### PR DESCRIPTION
- GameCore.cppのUpdate関数で開始前のオフセット待機処理をコメントアウトし、deltaTimeを直接使用するように変更。
- Lane.cppのInitialize関数でisHolding_の初期値を削除。
- GameScene.cppのUpdatePlaying関数で設定メニューの更新を削除し、ポーズメニューがアクティブな場合にゲームの状態をPausedに設定。
- GameScene.hでgameStartOffset_の値を3.0fから5.0fに変更。
- EngineのサブプロジェクトのコミットIDを更新。