### PR TITLE
譜面生成時の進行度を視覚化+非同期処理

### DIFF
--- a/Application/Source/Application/BeatMapEditor/AutoChartGenerator/autoChartGenerator.cpp
+++ b/Application/Source/Application/BeatMapEditor/AutoChartGenerator/autoChartGenerator.cpp
@@ -8,7 +8,8 @@
 #include <numeric>
 #include <chrono>
 
-std::vector<NoteData> BME::AutoChartGenerator::Generate(Engine::AudioSpectrum* spectrum, float duration, float bpm, float offset, const Settings& settings)
+
+std::vector<NoteData> BME::AutoChartGenerator::Generate(Engine::AudioSpectrum* spectrum, float duration, float bpm, float offset, const Settings& settings, std::atomic<float>* progress)
 {
     struct BandDef
     {
@@ -18,12 +19,15 @@ std::vector<NoteData> BME::AutoChartGenerator::Generate(Engine::AudioSpectrum* s
     };
 
     // TODO : 周波数帯域の定義を外部から受け取れるようにする
-    BandDef bands[] = {
+    std::vector<BandDef> bands = {
         { 0,    20,   150 }, // kick
         { 1,   150,   500 }, // bass
         { 2,   500,  2000 }, // mid
         { 3,  2000, 20000 }  // hi-hat
     };
+
+    int32_t totalBand = static_cast<int32_t>(bands.size());
+
     //BandDef bands[] = {
     //    { 0,    20,   3000},
     //};
@@ -36,10 +40,12 @@ std::vector<NoteData> BME::AutoChartGenerator::Generate(Engine::AudioSpectrum* s
     std::vector<NoteData> result;
     int32_t lane;
     lane = 0;// 無参照 回避用
-    for (auto& band : bands)
+    for (int32_t bandIndex = 0; bandIndex < totalBand; ++bandIndex)
     {
+        auto& band = bands[bandIndex];
+
         // 帯域毎のフラックスを計算 TODO：hopSec
-        FluxSeries flux = ComputeFlux(spectrum, duration, band.minHz, band.maxHz, 0.01f);
+        FluxSeries flux = ComputeFlux(spectrum, duration, band.minHz, band.maxHz, 0.01f, progress, band.laneIndex, totalBand);
         SmoothFlux(flux, 5); // 窓幅5フレーム（±2フレーム）
 
         // フラックスのピークから音セット時刻を検出
@@ -74,6 +80,9 @@ std::vector<NoteData> BME::AutoChartGenerator::Generate(Engine::AudioSpectrum* s
                   return a.targetTime < b.targetTime;
               });
 
+    if (progress)
+        progress->store(1.0f);
+
     auto endTime = std::chrono::high_resolution_clock::now();
     Engine::Debug::Log(std::format("Auto-chart generation complete: {} notes generated in {} ms\n",
                                    result.size(),
@@ -82,10 +91,13 @@ std::vector<NoteData> BME::AutoChartGenerator::Generate(Engine::AudioSpectrum* s
     return result;
 }
 
-BME::AutoChartGenerator::FluxSeries BME::AutoChartGenerator::ComputeFlux(Engine::AudioSpectrum* spectrum, float duration, float minHz, float maxHz, float hopSec)
+BME::AutoChartGenerator::FluxSeries BME::AutoChartGenerator::ComputeFlux(Engine::AudioSpectrum* spectrum, float duration, float minHz, float maxHz, float hopSec, std::atomic<float>* progress, int32_t bandIndex, int32_t totalBands)
 {
     FluxSeries series;
     std::vector<float> prev;
+
+    int32_t framesPerBand = static_cast<int32_t>(duration / hopSec);
+    int32_t frameIndex = 0;
 
     for (float t = 0.0f; t < duration; t += hopSec)
     {
@@ -114,6 +126,13 @@ BME::AutoChartGenerator::FluxSeries BME::AutoChartGenerator::ComputeFlux(Engine:
         series.flux.push_back(fluxVal);
 
         prev = curr;
+
+        if (progress)
+        {
+            float p = (bandIndex * framesPerBand + frameIndex) / static_cast<float>(framesPerBand * totalBands);
+            progress->store(p);
+        }
+        ++frameIndex;
     }
 
     return series;

--- a/Application/Source/Application/BeatMapEditor/AutoChartGenerator/autoChartGenerator.h
+++ b/Application/Source/Application/BeatMapEditor/AutoChartGenerator/autoChartGenerator.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Application/BeatMapLoader/BeatMapData.h>
+#include <atomic>
 
 namespace Engine { class AudioSpectrum; }
 
@@ -49,7 +50,8 @@ public:
         float duration,
         float bpm,
         float offset,
-        const Settings& settings
+        const Settings& settings,
+        std::atomic<float>* progress = nullptr
     );
 
 
@@ -71,7 +73,12 @@ private:
     /// <param name="maxHz">検出する周波数の上限</param>
     /// <param name="hopSec">FFTのホップサイズ（秒）</param>
     /// <returns>フラックスの時系列データ</returns>
-    FluxSeries ComputeFlux(Engine::AudioSpectrum* spectrum, float duration, float minHz, float maxHz, float hopSec);
+    FluxSeries ComputeFlux(Engine::AudioSpectrum* spectrum,
+                           float duration, float minHz, float maxHz, float hopSec,
+                           std::atomic<float>* progress = nullptr,
+                           int32_t bandIndex = 0,
+                           int32_t totalBands = 1
+                           );
 
     /// <summary>
     /// フラックスのピークを検出して、ノーツの時間を選び出す

--- a/Application/Source/Application/BeatMapEditor/BeatMapEditor.cpp
+++ b/Application/Source/Application/BeatMapEditor/BeatMapEditor.cpp
@@ -119,12 +119,30 @@ void BeatMapEditor::Update()
         &editorCoordinate_,
         beatManager_.get(),
         currentTime_,
-        autoGenerateRequest
+        autoGenerateRequest,
+        isGenerating_,
+        progress.load()
     );
 
     if (autoGenerateRequest.isRequested)
     {
         TriggerAutoGenerate(autoGenerateRequest.settings);
+    }
+
+    if (isGenerating_ &&
+        geanerateFuture_.valid() &&
+        geanerateFuture_.wait_for(std::chrono::seconds(0)) == std::future_status::ready)
+    {
+        auto generatedNotes = geanerateFuture_.get();
+        if (!generatedNotes.empty())
+        {
+            commandHistory_.ExecuteCommand(std::make_unique<BME::BatchInsertNotesCommand>(document_.get(), generatedNotes));
+        }
+        else
+        {
+            Debug::Log("Auto generation did not produce any notes.\n");
+        }
+        isGenerating_ = false;
     }
 
     for (auto it = voiceInstance_.begin(); it != voiceInstance_.end(); )
@@ -218,6 +236,8 @@ void BeatMapEditor::TriggerAutoGenerate(const BME::AutoChartGenerator::Settings&
 {
     if (!audioController_->HasAudio())
         return;
+    if (isGenerating_)
+        return;
 
     const size_t windowSize = 1ull << static_cast<size_t>(settings.windowN);
     auto spectrum = std::make_unique<Engine::AudioSpectrum>(windowSize);
@@ -230,14 +250,20 @@ void BeatMapEditor::TriggerAutoGenerate(const BME::AutoChartGenerator::Settings&
     float bpm = document_->GetData().bpm;
     float offset = document_->GetData().offset;
 
-    std::vector<NoteData> generatedNotes = autoChartGenerator_.Generate(spectrum.get(), duration, bpm, offset, settings);
+    isGenerating_ = true;
+    progress.store(0.0f);
 
-    if (generatedNotes.empty())
-    {
-        Debug::Log("Auto generation did not produce any notes.\n");
-        return;
-    }
+    geanerateFuture_ = std::async(std::launch::async, [this, spectrum = std::move(spectrum), duration, bpm, offset, settings]()
+                                  {
+                                      return autoChartGenerator_.Generate(spectrum.get(), duration, bpm, offset, settings, &progress);
+                                  });
 
-    commandHistory_.ExecuteCommand(std::make_unique<BME::BatchInsertNotesCommand>(document_.get(), generatedNotes));
+    //if (generatedNotes.empty())
+    //{
+    //    Debug::Log("Auto generation did not produce any notes.\n");
+    //    return;
+    //}
+
+    //commandHistory_.ExecuteCommand(std::make_unique<BME::BatchInsertNotesCommand>(document_.get(), generatedNotes));
 
 }

--- a/Application/Source/Application/BeatMapEditor/BeatMapEditor.h
+++ b/Application/Source/Application/BeatMapEditor/BeatMapEditor.h
@@ -14,8 +14,6 @@
 #include <Application/BeatsManager/BeatManager.h>
 #include <Application/BeatMapEditor/Command/CommandHistory.h>
 
-
-// 新アーキテクチャクラス
 #include <Application/BeatMapEditor/BeatMapDocument.h>
 #include <Application/BeatMapEditor/EditorState.h>
 #include <Application/BeatMapEditor/AudioController.h>
@@ -29,6 +27,8 @@
 #include <cstdint>
 #include <vector>
 #include <memory>
+#include <future>
+#include <atomic>
 
 // 前方宣言
 namespace Engine { class Input; class LineDrawer; }
@@ -115,9 +115,7 @@ private:
         bool isMoving = false; // 移動中フラグ
         std::vector<float> originalTimes; // 元の時間
         std::vector<size_t> movingIndices; // 移動対象のノートインデックス
-
     };
-
 
     struct ClipboardData
     {
@@ -170,6 +168,10 @@ private:
     std::shared_ptr<Engine::SoundInstance> soundInstance_ = nullptr;
     std::vector<std::shared_ptr<Engine::VoiceInstance>> voiceInstance_;
 
+
+    std::atomic<float> progress{ 0.0f };
+    std::future<std::vector<NoteData>> geanerateFuture_;
+    bool isGenerating_ = false;
 };
 /*
 

--- a/Application/Source/Application/BeatMapEditor/Render/EditorRenderer.cpp
+++ b/Application/Source/Application/BeatMapEditor/Render/EditorRenderer.cpp
@@ -34,7 +34,9 @@ void EditorRenderer::Update(
     EditorCoordinate* _coordinate,
     BeatManager* beatManager,
     float& _currentTime,
-    AutoChartGenerator::GenerateRequest& autoGenerateRequest
+    AutoChartGenerator::GenerateRequest& autoGenerateRequest,
+    bool isGenerating,
+    float progress
     )
 {
     if (!_state || !_document || !_audioController || !_coordinate)
@@ -50,7 +52,9 @@ void EditorRenderer::Update(
                             _fileManager,
                             beatManager,
                             _coordinate,
-                            autoGenerateRequest);
+                            autoGenerateRequest,
+                            isGenerating,
+                            progress);
 }
 
 void EditorRenderer::Draw(

--- a/Application/Source/Application/BeatMapEditor/Render/EditorRenderer.h
+++ b/Application/Source/Application/BeatMapEditor/Render/EditorRenderer.h
@@ -35,7 +35,9 @@ public:
         EditorCoordinate* _coordinate,
         BeatManager* beatManager,
         float& _currentTime,
-        AutoChartGenerator::GenerateRequest& autoGenerateRequest
+        AutoChartGenerator::GenerateRequest& autoGenerateRequest,
+        bool isGenerating,
+        float progress
     );
     void Draw(
         State* _state,

--- a/Application/Source/Application/BeatMapEditor/Render/EditorUIController.cpp
+++ b/Application/Source/Application/BeatMapEditor/Render/EditorUIController.cpp
@@ -31,11 +31,14 @@ void EditorUIController::ProcessUI(
     [[maybe_unused]] FileManager* fileManager,
     [[maybe_unused]] BeatManager* beatManager,
     [[maybe_unused]] EditorCoordinate* coordinate,
-    [[maybe_unused]] AutoChartGenerator::GenerateRequest& autoGenerateRequest)
+    [[maybe_unused]] AutoChartGenerator::GenerateRequest& autoGenerateRequest,
+    bool isGenerating,
+    float progress
+)
 {
 #ifdef _DEBUG
     DrawLeftPanel(state, document, audioController, beatManager, coordinate);
-    DrawRightPanel(state, document, audioController, fileManager, autoGenerateRequest);
+    DrawRightPanel(state, document, audioController, fileManager, autoGenerateRequest, isGenerating, progress);
 #endif
     UpdateDraggingArea(state);
 }
@@ -189,7 +192,14 @@ void EditorUIController::DrawLeftPanel(State* state, Document* document, AudioCo
 
 }
 
-void EditorUIController::DrawRightPanel(State* state, Document* document, AudioController* audioController, FileManager* fileManager, AutoChartGenerator::GenerateRequest& autoGenerateRequest)
+void EditorUIController::DrawRightPanel(State* state,
+                                        Document* document,
+                                        AudioController* audioController,
+                                        FileManager* fileManager,
+                                        AutoChartGenerator::GenerateRequest& autoGenerateRequest,
+                                        bool isGenerating,
+                                        float progress
+)
 {
 
     // File 情報
@@ -211,8 +221,6 @@ void EditorUIController::DrawRightPanel(State* state, Document* document, AudioC
                  ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoTitleBar);
     {
         ImGui::SeparatorText("BeatMap Info");
-
-        ImGui::Dummy(ImVec2(0.0f, spacing)); // スペーシングを追加
 
         ImGui::Text("Current File:");
         ImGui::Text("\t%s", currentPath.empty() ? "None" : StringUtils::GetAfterLast(currentPath, "\\").c_str());
@@ -275,10 +283,8 @@ void EditorUIController::DrawRightPanel(State* state, Document* document, AudioC
             ImGui::EndPopup();
         }
 
-        ImGui::Dummy(ImVec2(0.0f, spacing / 2.0f)); // スペーシングを追加
         ImGui::Text("Notes : %zu", data.notes.size());
 
-        ImGui::Dummy(ImVec2(0.0f, spacing)); // スペーシングを追加
 
         /// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -314,29 +320,40 @@ void EditorUIController::DrawRightPanel(State* state, Document* document, AudioC
             }
         }
 
-
         // パネル下部に固定（セクションの高さ分を引く）
-        const float autoGenSectionHeight = 135.0f; // セクションの大体の高さ
+        const float autoGenSectionHeight = 200.0f; // セクションの大体の高さ
         ImGui::SetCursorPosY(panelSize.y - autoGenSectionHeight);
 
         ImGui::SeparatorText("Auto Generate");
-
-        ImGui::SliderFloat("Sensitivity", &autoGenerateRequest.settings.sensitivity, 0.0f, 1.0f);
-        ImGui::SliderFloat("Min Note Gap", &autoGenerateRequest.settings.minNoteGap, 0.05f, 0.5f);
-        ImGui::Checkbox("Snap To Grid", &autoGenerateRequest.settings.snapToGrid);
-        ImGui::SameLine();
-        ImGui::Checkbox("Use GPU", &autoGenerateRequest.settings.useGpuFFT);
-        ImGui::SliderInt("Grid Division", &autoGenerateRequest.settings.gridDivision, 1, 16);
-        ImGui::SliderInt("FFT Window N", &autoGenerateRequest.settings.windowN, 8, 20);
-
-        ImGui::BeginDisabled(!audioController->HasAudio()); // 音楽未ロードなら無効
+        if (isGenerating)
         {
-            if (ImGui::Button("Generate"))
-            {
-                autoGenerateRequest.isRequested = true;
-            }
+            ImGui::Dummy({0.0f,20.0f});
+            ImGui::Dummy({0.0f,20.0f});
+            ImGui::ProgressBar(progress, ImVec2(-1.0f, 0.0f)); // 進行状況を表示
+            ImGui::Text("Generating... %.1f%%", progress * 100.0f); // 進行状況のテキスト表示
+            ImGui::Dummy({0.0f,20.0f});
+            ImGui::Dummy({0.0f,20.0f});
         }
-        ImGui::EndDisabled();
+        else
+        {
+            ImGui::SliderFloat("Sensitivity", &autoGenerateRequest.settings.sensitivity, 0.0f, 1.0f);
+            ImGui::SliderFloat("Min Note Gap", &autoGenerateRequest.settings.minNoteGap, 0.05f, 0.5f);
+            ImGui::Checkbox("Snap To Grid", &autoGenerateRequest.settings.snapToGrid);
+            ImGui::SameLine();
+            ImGui::Checkbox("Use GPU", &autoGenerateRequest.settings.useGpuFFT);
+            ImGui::SliderInt("Grid Division", &autoGenerateRequest.settings.gridDivision, 1, 16);
+            ImGui::SliderInt("FFT Window N", &autoGenerateRequest.settings.windowN, 8, 20);
+
+            ImGui::BeginDisabled(!audioController->HasAudio()); // 音楽未ロードなら無効
+            {
+                if (ImGui::Button("Generate"))
+                {
+                    autoGenerateRequest.isRequested = true;
+                }
+            }
+            ImGui::EndDisabled();
+        }
+
 
     }
     ImGui::End();

--- a/Application/Source/Application/BeatMapEditor/Render/EditorUIController.h
+++ b/Application/Source/Application/BeatMapEditor/Render/EditorUIController.h
@@ -29,7 +29,10 @@ public:
                    FileManager* fileManager,
                    BeatManager* beatManager,
                    EditorCoordinate* coordinate,
-                   AutoChartGenerator::GenerateRequest& autoGenerateRequest);
+                   AutoChartGenerator::GenerateRequest& autoGenerateRequest,
+                   bool isGenerating,
+                   float progress
+    );
     void Draw(const State* state) const;
     void Finalize();
 
@@ -37,7 +40,14 @@ public:
 private:
 #ifdef _DEBUG
     void DrawLeftPanel(State* state, Document* document, AudioController* audioController, BeatManager* beatManager, EditorCoordinate* coordinate_);
-    void DrawRightPanel(State* state, Document* document, AudioController* audioController, FileManager* fileManager, AutoChartGenerator::GenerateRequest& autoGenerateRequest);
+    void DrawRightPanel(State* state,
+                        Document* document,
+                        AudioController* audioController,
+                        FileManager* fileManager,
+                        AutoChartGenerator::GenerateRequest& autoGenerateRequest,
+                        bool isGenerating,
+                        float progress
+    );
 #endif // _DEBUG
     void UpdateDraggingArea(const State* state);
     void DrawDraggingArea(const State* state) const;

--- a/Application/imgui.ini
+++ b/Application/imgui.ini
@@ -1,5 +1,5 @@
 [Window][WindowOverViewport_11111111]
-Pos=0,24
+Pos=0,0
 Size=46,32
 Collapsed=0
 
@@ -111,6 +111,7 @@ Size=278,145
 Collapsed=0
 
 [Window][Editor Controls]
+Pos=0,0
 Size=300,620
 Collapsed=0
 
@@ -120,7 +121,7 @@ Size=300,620
 Collapsed=0
 
 [Window][Tap BPM Counter]
-Pos=60,61
+Pos=60,76
 Size=329,184
 Collapsed=0
 
@@ -170,7 +171,7 @@ DockNode          ID=0x00000001 Pos=821,72 Size=458,626 Split=X Selected=0x933EC
     DockNode      ID=0x00000004 Parent=0x00000002 SizeRef=198,177 Selected=0xF07A5C35
     DockNode      ID=0x00000005 Parent=0x00000002 SizeRef=198,447 Selected=0xA9743CEC
   DockNode        ID=0x00000003 Parent=0x00000001 SizeRef=234,626 Selected=0x933ECD57
-DockSpace         ID=0x08BD597D Window=0x1BBC0F80 Pos=0,24 Size=32,32 Split=Y
+DockSpace         ID=0x08BD597D Window=0x1BBC0F80 Pos=0,0 Size=32,32 Split=Y
   DockNode        ID=0x0000000C Parent=0x08BD597D SizeRef=1280,482 Split=Y
     DockNode      ID=0x0000000A Parent=0x0000000C SizeRef=1280,426 Split=Y
       DockNode    ID=0x00000008 Parent=0x0000000A SizeRef=1280,499 Split=Y


### PR DESCRIPTION
- autoChartGenerator.cpp で `Generate` メソッドに進行状況を追跡するための `std::atomic<float>* progress` 引数を追加
- 周波数帯域の定義を配列からベクターに変更し、フラックス計算に進行状況更新ロジックを追加
- `ComputeFlux` メソッドの引数も変更し、進行状況を管理できるように
- autoChartGenerator.h で `Generate` と `ComputeFlux` メソッドのシグネチャを変更し、`#include <atomic>` を追加
- BeatMapEditor.cpp で `std::async` を使用してオート生成リクエストを非同期で処理
- 進行状況を示す `std::atomic<float> progress` と生成中の状態を管理する `isGenerating_` フラグを追加
- BeatMapEditor.h で進行状況を追跡するための `std::atomic<float> progress` と生成タスクの結果を保持する `std::future<std::vector<NoteData>> geanerateFuture_` を追加
- EditorRenderer.cpp と EditorUIController.cpp でUIに進行状況を表示するための引数を追加